### PR TITLE
Refactor puck handling and fix setup issues

### DIFF
--- a/Puckslide/Assets/Scripts/GameSetupManager.cs
+++ b/Puckslide/Assets/Scripts/GameSetupManager.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEditor.TestTools.CodeCoverage;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/Puckslide/Assets/Scripts/GridManager.cs
+++ b/Puckslide/Assets/Scripts/GridManager.cs
@@ -52,7 +52,11 @@ public class GridManager : MonoBehaviour
 
             if (puck.CurrentGridPosition != new Vector2Int(-1, -1))
             {
-                m_PieceLayout.Add(puck.CurrentGridPosition, puck.ChessPiece);
+                if (m_PieceLayout.ContainsKey(puck.CurrentGridPosition))
+                {
+                    Debug.LogWarning($"Duplicate piece at {puck.CurrentGridPosition} replaced.");
+                }
+                m_PieceLayout[puck.CurrentGridPosition] = puck.ChessPiece;
             }
         }
         

--- a/Puckslide/Assets/Scripts/OneWayWall.cs
+++ b/Puckslide/Assets/Scripts/OneWayWall.cs
@@ -1,45 +1,40 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 public class OneWayWall : MonoBehaviour
 {
-    // private int puckLayer;
-    // private int oneWayWallLayer;
-    //
-    // private void Awake()
-    // {
-    //     puckLayer = LayerMask.NameToLayer("Puck");
-    //     oneWayWallLayer = LayerMask.NameToLayer("OneWayWall");
-    // }
-    //
-    // private void FixedUpdate()
-    // {
-    //     // Find all pucks in the scene
-    //     GameObject[] pucks = GameObject.FindGameObjectsWithTag("Puck");
-    //
-    //     foreach (GameObject puck in pucks)
-    //     {
-    //         Rigidbody2D rb = puck.GetComponent<Rigidbody2D>();
-    //
-    //         if (rb != null)
-    //         {
-    //             // Allow puck to pass through wall when moving upward
-    //             if (rb.velocity.y > 0)
-    //             {
-    //                 Physics2D.IgnoreLayerCollision(puckLayer, oneWayWallLayer, true);
-    //             }
-    //             // Enable collision when puck moves downward
-    //             else if (rb.velocity.y <= 0)
-    //             {
-    //                 Physics2D.IgnoreLayerCollision(puckLayer, oneWayWallLayer, false);
-    //             }
-    //         }
-    //     }
-    // }
-    
     private int puckLayer;       // Original layer for pucks
     private int ignoreWallLayer; // Layer where pucks pass through the wall
     private int oneWayWallLayer; // Layer for the one-way wall
+
+    private readonly List<Rigidbody2D> m_Pucks = new List<Rigidbody2D>();
+
+    private void OnEnable()
+    {
+        EventsManager.OnPuckSpawned.AddListener(RegisterPuck);
+        EventsManager.OnPuckDespawned.AddListener(UnregisterPuck);
+    }
+
+    private void OnDisable()
+    {
+        EventsManager.OnPuckSpawned.RemoveListener(RegisterPuck);
+        EventsManager.OnPuckDespawned.RemoveListener(UnregisterPuck);
+        m_Pucks.Clear();
+    }
+
+    private void RegisterPuck(Rigidbody2D rb)
+    {
+        if (rb != null && !m_Pucks.Contains(rb))
+        {
+            m_Pucks.Add(rb);
+        }
+    }
+
+    private void UnregisterPuck(Rigidbody2D rb)
+    {
+        m_Pucks.Remove(rb);
+    }
 
     private void Start()
     {
@@ -50,29 +45,39 @@ public class OneWayWall : MonoBehaviour
         // Ensure layer collisions are initially enabled
         Physics2D.IgnoreLayerCollision(puckLayer, oneWayWallLayer, false);
         Physics2D.IgnoreLayerCollision(ignoreWallLayer, oneWayWallLayer, true);
+
+        // Cache any pucks already in the scene
+        GameObject[] pucks = GameObject.FindGameObjectsWithTag("Puck");
+        foreach (GameObject puck in pucks)
+        {
+            Rigidbody2D rb = puck.GetComponent<Rigidbody2D>();
+            if (rb != null)
+            {
+                m_Pucks.Add(rb);
+            }
+        }
     }
 
     private void FixedUpdate()
     {
-        // Find all pucks in the scene
-        GameObject[] pucks = GameObject.FindGameObjectsWithTag("Puck");
-
-        foreach (GameObject puck in pucks)
+        for (int i = m_Pucks.Count - 1; i >= 0; i--)
         {
-            Rigidbody2D rb = puck.GetComponent<Rigidbody2D>();
-
-            if (rb != null)
+            Rigidbody2D rb = m_Pucks[i];
+            if (rb == null)
             {
-                if (rb.velocity.y > 0)
-                {
-                    // Moving upward: switch layer to IgnoreWall to pass through
-                    puck.layer = ignoreWallLayer;
-                }
-                else if (rb.velocity.y <= 0)
-                {
-                    // Moving downward: switch layer back to Puck to enable bouncing
-                    puck.layer = puckLayer;
-                }
+                m_Pucks.RemoveAt(i);
+                continue;
+            }
+
+            if (rb.velocity.y > 0)
+            {
+                // Moving upward: switch layer to IgnoreWall to pass through
+                rb.gameObject.layer = ignoreWallLayer;
+            }
+            else
+            {
+                // Moving downward: switch layer back to Puck to enable bouncing
+                rb.gameObject.layer = puckLayer;
             }
         }
     }

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -13,22 +13,29 @@ public class PuckController : MonoBehaviour
 
     [SerializeField]
     private Sprite[] m_Sprites;
-    
+
     private Vector3 m_DragStartPos;
-    private bool m_IsBeingDragged;
+    private Camera m_Camera;
 
     private bool m_IsSticky;
     
     private const float STOP_THRESHOLD = 0.05f;
 
+    private void Awake()
+    {
+        m_Camera = Camera.main;
+    }
+
     private void OnEnable()
     {
         EventsManager.OnDeletePucks.AddListener(OnDelete);
+        EventsManager.OnPuckSpawned.Invoke(m_Rigidbody);
     }
-    
+
     private void OnDisable()
     {
         EventsManager.OnDeletePucks.RemoveListener(OnDelete);
+        EventsManager.OnPuckDespawned.Invoke(m_Rigidbody);
     }
 
     private void OnDelete(bool delete)
@@ -94,8 +101,7 @@ public class PuckController : MonoBehaviour
             m_Rigidbody.bodyType = RigidbodyType2D.Dynamic;
         }
         
-        m_DragStartPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
-        m_IsBeingDragged = true;
+        m_DragStartPos = m_Camera.ScreenToWorldPoint(Input.mousePosition);
         
         if (m_LineRenderer != null)
         {
@@ -111,7 +117,7 @@ public class PuckController : MonoBehaviour
     {
         if (m_LineRenderer != null && m_LineRenderer.enabled)
         {
-            Vector3 dragPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+            Vector3 dragPos = m_Camera.ScreenToWorldPoint(Input.mousePosition);
             dragPos.z = 0; 
 
             Vector3 puckCenter = transform.position;
@@ -124,15 +130,13 @@ public class PuckController : MonoBehaviour
 
     private void OnMouseUp()
     {
-        Vector3 dragEndPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+        Vector3 dragEndPos = m_Camera.ScreenToWorldPoint(Input.mousePosition);
         Vector2 dragVector = (m_DragStartPos - dragEndPos);
 
         float power = 5f;
         m_Rigidbody.bodyType = RigidbodyType2D.Dynamic;
         m_Rigidbody.AddForce(dragVector * power, ForceMode2D.Impulse);
 
-        m_IsBeingDragged = false;
-        
         if (m_LineRenderer != null)
         {
             m_LineRenderer.enabled = false;

--- a/Puckslide/Assets/Scripts/UI/Phase1PieceButton.cs
+++ b/Puckslide/Assets/Scripts/UI/Phase1PieceButton.cs
@@ -36,8 +36,9 @@ public class Phase1PieceButton : MonoBehaviour
     
     private void OnDisable()
     {
-        EventsManager.OnPieceSetupData.AddListener(OnPieceSetup, true);
+        EventsManager.OnPieceSetupData.RemoveListener(OnPieceSetup);
         m_Button.onClick.RemoveListener(OnButtonPress);
+        m_PieceCount = 0;
         m_PieceCountText.text = "X 0";
     }
 

--- a/Puckslide/Assets/Scripts/Util/EventsManager.cs
+++ b/Puckslide/Assets/Scripts/Util/EventsManager.cs
@@ -6,8 +6,10 @@ public static class EventsManager
 {
     public static readonly Evt<bool> OnDeletePucks = new Evt<bool>();
     public static readonly Evt<PieceSetupData[]> OnPieceSetupData = new Evt<PieceSetupData[]>();
-    
+
     public static readonly Evt<Dictionary<Vector2Int, ChessPiece>> OnBoardLayout = new Evt<Dictionary<Vector2Int, ChessPiece>>();
+    public static readonly Evt<Rigidbody2D> OnPuckSpawned = new Evt<Rigidbody2D>();
+    public static readonly Evt<Rigidbody2D> OnPuckDespawned = new Evt<Rigidbody2D>();
 }
 
 


### PR DESCRIPTION
## Summary
- remove duplicate piece-setup listener and reset counter on phase buttons
- drop editor-only dependency from `GameSetupManager`
- guard against duplicate board coordinates in `GridManager`
- cache puck rigidbodies for `OneWayWall` via spawn/despawn events
- cache `Camera.main` and emit puck spawn/despawn events in `PuckController`

## Testing
- `dotnet build Puckslide/Assembly-CSharp.csproj` *(fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68988c9848d8832faced0e66083bdba9