### PR TITLE
Flip board after each turn

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+public static class BoardFlipper
+{
+    private static bool s_IsFlipped = false;
+
+    public static void Flip()
+    {
+        if (Camera.main == null)
+        {
+            return;
+        }
+
+        s_IsFlipped = !s_IsFlipped;
+        float angle = s_IsFlipped ? 180f : 0f;
+        Camera.main.transform.rotation = Quaternion.Euler(0f, 0f, angle);
+    }
+}

--- a/Puckslide/Assets/Scripts/BoardFlipper.cs.meta
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d96e2bbde6574bc680e184f8dd85bab4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Puckslide/Assets/Scripts/Chess/BoardController.cs
+++ b/Puckslide/Assets/Scripts/Chess/BoardController.cs
@@ -203,6 +203,8 @@ public class BoardController : MonoBehaviour
                     // Show the promotion UI
                     PromotionPanel.Instance.ShowPanel(m_SelectedPiece, tileBelow);
                 }
+
+                BoardFlipper.Flip();
             }
             else
             {

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using UnityEngine;
 
 public class PuckController : MonoBehaviour
@@ -141,6 +142,24 @@ public class PuckController : MonoBehaviour
         {
             m_LineRenderer.enabled = false;
         }
+
+        StartCoroutine(WaitForAllPucksStopped());
+    }
+
+    private IEnumerator WaitForAllPucksStopped()
+    {
+        yield return new WaitUntil(() =>
+        {
+            foreach (PuckController puck in FindObjectsOfType<PuckController>())
+            {
+                if (puck.m_Rigidbody.velocity.magnitude > STOP_THRESHOLD)
+                {
+                    return false;
+                }
+            }
+            return true;
+        });
+        BoardFlipper.Flip();
     }
     
     public Vector2Int CurrentGridPosition { get; private set; } // Store the grid position of this puck


### PR DESCRIPTION
## Summary
- add `BoardFlipper` utility to toggle the main camera 180°
- flip camera after chess move and after puck motion settles for alternating viewpoints

## Testing
- `dotnet build Puckslide/Puckslide.sln` *(fails: reference assemblies for .NET Framework v4.7.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68989318b848832fa871ab6f5997e47a