### PR TITLE
Flip board visuals only and alternate turns

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -3,16 +3,42 @@ using UnityEngine;
 public static class BoardFlipper
 {
     private static bool s_IsFlipped = false;
+    private static Transform s_BoardTransform;
+    private static Vector3 s_BoardCenter;
+
+    public static void SetBoard(Transform board, int gridSize, float tileSize)
+    {
+        s_BoardTransform = board;
+        s_BoardCenter = board.position + new Vector3(gridSize * tileSize / 2f, gridSize * tileSize / 2f, 0f);
+    }
 
     public static void Flip()
     {
-        if (Camera.main == null)
+        if (s_BoardTransform == null)
         {
             return;
         }
 
         s_IsFlipped = !s_IsFlipped;
         float angle = s_IsFlipped ? 180f : 0f;
-        Camera.main.transform.rotation = Quaternion.Euler(0f, 0f, angle);
+        s_BoardTransform.rotation = Quaternion.Euler(0f, 0f, angle);
+
+        foreach (PuckController puck in Object.FindObjectsOfType<PuckController>())
+        {
+            if (!puck.transform.IsChildOf(s_BoardTransform))
+            {
+                puck.transform.RotateAround(s_BoardCenter, Vector3.forward, 180f);
+            }
+            puck.transform.rotation = Quaternion.identity;
+        }
+
+        foreach (Piece piece in Object.FindObjectsOfType<Piece>())
+        {
+            if (!piece.transform.IsChildOf(s_BoardTransform))
+            {
+                piece.transform.RotateAround(s_BoardCenter, Vector3.forward, 180f);
+            }
+            piece.transform.rotation = Quaternion.identity;
+        }
     }
 }

--- a/Puckslide/Assets/Scripts/Chess/BoardController.cs
+++ b/Puckslide/Assets/Scripts/Chess/BoardController.cs
@@ -27,7 +27,7 @@ public class BoardController : MonoBehaviour
     private Piece m_SelectedPiece;
     private Vector3 m_Offset;
     private Tile m_OriginalTile;
-    private bool m_IsWhiteTurn = true;
+    private bool? m_LastMoveWasWhite = null;
 
     private void OnEnable()
     {
@@ -44,6 +44,7 @@ public class BoardController : MonoBehaviour
         }
         
         EventsManager.OnBoardLayout.AddListener(OnBoardLayout, true);
+        m_LastMoveWasWhite = null;
     }
     
     private void OnDisable()
@@ -132,7 +133,7 @@ public class BoardController : MonoBehaviour
             }
 
             // If we found a piece, check turn and "pick it up"
-            if (topmostPiece != null && topmostPiece.IsWhite() == m_IsWhiteTurn)
+            if (topmostPiece != null && (m_LastMoveWasWhite == null || topmostPiece.IsWhite() != m_LastMoveWasWhite.Value))
             {
                 m_SelectedPiece = topmostPiece;
                 m_OriginalTile = m_SelectedPiece.GetCurrentTile();
@@ -200,7 +201,7 @@ public class BoardController : MonoBehaviour
                     PromotionPanel.Instance.ShowPanel(m_SelectedPiece, tileBelow);
                 }
 
-                m_IsWhiteTurn = !m_IsWhiteTurn;
+                m_LastMoveWasWhite = m_SelectedPiece.IsWhite();
                 BoardFlipper.Flip();
                 moveMade = true;
             }

--- a/Puckslide/Assets/Scripts/GameSetupManager.cs
+++ b/Puckslide/Assets/Scripts/GameSetupManager.cs
@@ -48,7 +48,8 @@ public class GameSetupManager : MonoBehaviour
     private void OnEnable()
     {
         EventsManager.OnDeletePucks.Invoke(true);
-        
+        PuckController.ResetTurnOrder();
+
         m_PieceSetup = new PieceSetupData[]
         {
             new PieceSetupData { Type = ChessPieceType.Pawn,   WhiteCount=0, BlackCount=0, Sticky=false },

--- a/Puckslide/Assets/Scripts/GridGenerator.cs
+++ b/Puckslide/Assets/Scripts/GridGenerator.cs
@@ -7,6 +7,11 @@ public class GridGenerator : MonoBehaviour
     [SerializeField] private int m_GridSize = 8;
     [SerializeField] private float m_TileSize = 0.383f;
 
+    private void Awake()
+    {
+        BoardFlipper.SetBoard(transform, m_GridSize, m_TileSize);
+    }
+
     private void Start()
     {
         GenerateGrid();


### PR DESCRIPTION
## Summary
- flip only the board and pieces instead of the whole camera
- keep pieces upright and rotate around board center when flipping
- enforce alternating turns in both puck sliding and chess phases

## Testing
- `dotnet build Puckslide.sln` *(fails: command not found)*
- `apt-get update`
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6898c20c5ab8832fa8289c820df8e93c