### PR TITLE
Fix board flipping center offset

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -8,6 +8,7 @@ public static class BoardFlipper
     private static int s_GridSize;
     private static float s_TileSize;
 
+    private static Vector3 s_BoardCenter;
 
     public static void SetBoard(Transform board, int gridSize, float tileSize)
     {
@@ -15,11 +16,13 @@ public static class BoardFlipper
 
         s_GridSize = gridSize;
         s_TileSize = tileSize;
+
+        s_BoardCenter = board.position + new Vector3((gridSize - 1) * tileSize / 2f, (gridSize - 1) * tileSize / 2f, 0f);
     }
 
     private static Vector3 GetBoardCenter()
     {
-        return s_BoardTransform.position + new Vector3(s_GridSize * s_TileSize / 2f, s_GridSize * s_TileSize / 2f, 0f);
+        return s_BoardCenter;
 
     }
 


### PR DESCRIPTION
## Summary
- Precompute and store board center using grid size minus 1 to correct half-tile offset
- Use stored center for rotations so board flips around consistent point

## Testing
- `dotnet build Puckslide/Puckslide.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*
- `mcs Puckslide/Assets/Scripts/BoardFlipper.cs -target:library -out:/tmp/BoardFlipper.dll` *(fails: UnityEngine not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898c7de1e1c832f83964b19251aa612