### PR TITLE
Stabilize board flip physics and enforce starting turn order

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -48,6 +48,13 @@ public static class BoardFlipper
 
             }
             puck.transform.rotation = Quaternion.identity;
+
+            Rigidbody2D rb = puck.GetComponent<Rigidbody2D>();
+            if (rb != null)
+            {
+                rb.velocity = Vector2.zero;
+                rb.angularVelocity = 0f;
+            }
         }
 
         foreach (Piece piece in Object.FindObjectsOfType<Piece>())
@@ -59,6 +66,13 @@ public static class BoardFlipper
 
             }
             piece.transform.rotation = Quaternion.identity;
+
+            Rigidbody2D rb = piece.GetComponent<Rigidbody2D>();
+            if (rb != null)
+            {
+                rb.velocity = Vector2.zero;
+                rb.angularVelocity = 0f;
+            }
         }
     }
 }

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -192,7 +192,7 @@ public class PuckController : MonoBehaviour
 
     public static void ResetTurnOrder()
     {
-        s_LastMoveWasWhite = null;
+        s_LastMoveWasWhite = false; // Start with white's turn
     }
 
     public void UpdateGridPosition(float tileSize, Vector2 gridOrigin)


### PR DESCRIPTION
## Summary
- Reset rigidbody velocity and angular velocity for pucks and pieces when the board flips to stop them from flying off the board
- Initialize turn tracking so white always moves first, preventing out‑of‑turn puck selection at the start of phase 1

## Testing
- `dotnet build Puckslide/Assembly-CSharp.csproj` *(fails: reference assemblies for .NETFramework,Version=v4.7.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb387544832fb1ae8fd1affdadd2