### PR TITLE
Fix board flip timing and piece persistence

### DIFF
--- a/Puckslide/Assets/Scripts/Chess/BoardController.cs
+++ b/Puckslide/Assets/Scripts/Chess/BoardController.cs
@@ -83,7 +83,7 @@ public class BoardController : MonoBehaviour
                 }
 
                 // 2) Instantiate the piece prefab at the tile's position
-                GameObject pieceObj = Instantiate(m_PiecePrefab, tile.transform.position, Quaternion.identity);
+                GameObject pieceObj = Instantiate(m_PiecePrefab, tile.transform.position, Quaternion.identity, tile.transform);
 
                 // 3) Get the piece script and call SetupPiece
                 Piece pieceScript = pieceObj.GetComponent<Piece>();
@@ -92,6 +92,7 @@ public class BoardController : MonoBehaviour
                     pieceScript.SetupPiece(pieceType);
                     tile.SetPiece(pieceScript);
                     pieceScript.SetTile(tile);
+                    pieceScript.transform.SetParent(tile.transform);
                 }
                 else
                 {
@@ -140,6 +141,7 @@ public class BoardController : MonoBehaviour
 
                 if (m_OriginalTile != null)
                 {
+                    m_SelectedPiece.transform.SetParent(null);
                     m_OriginalTile.ClearTile();
                 }
             }
@@ -195,6 +197,7 @@ public class BoardController : MonoBehaviour
                 tileBelow.SetPiece(m_SelectedPiece);
                 m_SelectedPiece.SetTile(tileBelow);
                 m_SelectedPiece.transform.position = tileBelow.transform.position;
+                m_SelectedPiece.transform.SetParent(tileBelow.transform);
 
                 if (m_SelectedPiece.IsPawn() && (tileBelow.GetRow() == 0 || tileBelow.GetRow() == 7))
                 {
@@ -210,6 +213,8 @@ public class BoardController : MonoBehaviour
             {
                 m_SelectedPiece.transform.position = m_OriginalTile.transform.position;
                 m_OriginalTile.SetPiece(m_SelectedPiece);
+                m_SelectedPiece.SetTile(m_OriginalTile);
+                m_SelectedPiece.transform.SetParent(m_OriginalTile.transform);
             }
 
             m_SelectedPiece = null;

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -171,11 +171,13 @@ public class PuckController : MonoBehaviour
 
     private IEnumerator WaitForAllPucksStopped()
     {
+        // Allow physics to update before checking velocities
+        yield return new WaitForFixedUpdate();
         yield return new WaitUntil(() =>
         {
             foreach (PuckController puck in FindObjectsOfType<PuckController>())
             {
-                if (puck.m_Rigidbody.velocity.magnitude > STOP_THRESHOLD)
+                if (!puck.m_Rigidbody.IsSleeping())
                 {
                     return false;
                 }


### PR DESCRIPTION
## Summary
- Parent chess pieces to board tiles so they stay visible when the board flips
- Delay flip in phase 1 until all pucks are sleeping to ensure motion stops first

## Testing
- `dotnet build Puckslide/Assembly-CSharp.csproj` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_6898cea63e24832f845ca9288c601873