### PR TITLE
Fix board flipping and phase two piece mirroring

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -38,15 +38,14 @@ public static class BoardFlipper
         Vector3 boardCenter = GetBoardCenter();
         s_BoardTransform.RotateAround(boardCenter, Vector3.forward, 180f);
 
-
         foreach (PuckController puck in Object.FindObjectsOfType<PuckController>())
         {
             if (!puck.transform.IsChildOf(s_BoardTransform))
             {
-
-                puck.transform.RotateAround(boardCenter, Vector3.forward, 180f);
-
+                Vector3 offset = puck.transform.position - boardCenter;
+                puck.transform.position = boardCenter - offset;
             }
+
             puck.transform.rotation = Quaternion.identity;
 
             Rigidbody2D rb = puck.GetComponent<Rigidbody2D>();
@@ -61,10 +60,10 @@ public static class BoardFlipper
         {
             if (!piece.transform.IsChildOf(s_BoardTransform))
             {
-
-                piece.transform.RotateAround(boardCenter, Vector3.forward, 180f);
-
+                Vector3 offset = piece.transform.position - boardCenter;
+                piece.transform.position = boardCenter - offset;
             }
+
             piece.transform.rotation = Quaternion.identity;
 
             Rigidbody2D rb = piece.GetComponent<Rigidbody2D>();

--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -17,7 +17,7 @@ public static class BoardFlipper
         s_GridSize = gridSize;
         s_TileSize = tileSize;
 
-        s_BoardCenter = board.position + new Vector3((gridSize - 1) * tileSize / 2f, (gridSize - 1) * tileSize / 2f, 0f);
+        s_BoardCenter = board.position;
     }
 
     private static Vector3 GetBoardCenter()

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -166,6 +166,13 @@ public class PuckController : MonoBehaviour
         s_LastMoveWasWhite = IsWhitePiece;
         m_IsSelected = false;
 
+        StartCoroutine(WaitForPuckStopped());
+    }
+
+    private IEnumerator WaitForPuckStopped()
+    {
+        yield return new WaitForFixedUpdate();
+        yield return new WaitUntil(() => m_Rigidbody.velocity.magnitude <= STOP_THRESHOLD);
         BoardFlipper.Flip();
     }
 

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -166,24 +166,6 @@ public class PuckController : MonoBehaviour
         s_LastMoveWasWhite = IsWhitePiece;
         m_IsSelected = false;
 
-        StartCoroutine(WaitForAllPucksStopped());
-    }
-
-    private IEnumerator WaitForAllPucksStopped()
-    {
-        // Allow physics to update before checking velocities
-        yield return new WaitForFixedUpdate();
-        yield return new WaitUntil(() =>
-        {
-            foreach (PuckController puck in FindObjectsOfType<PuckController>())
-            {
-                if (!puck.m_Rigidbody.IsSleeping())
-                {
-                    return false;
-                }
-            }
-            return true;
-        });
         BoardFlipper.Flip();
     }
 


### PR DESCRIPTION
## Summary
- Mirror pucks and pieces across board center when flipping to keep them on screen
- Restore immediate board flip after releasing a puck in phase 1

## Testing
- `dotnet build Puckslide/Assembly-CSharp.csproj` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_6898d16bcbd0832f869d17e7beedca57