### PR TITLE
Fix board flip to stay centered

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -17,7 +17,11 @@ public static class BoardFlipper
         s_GridSize = gridSize;
         s_TileSize = tileSize;
 
-        s_BoardCenter = board.position;
+        // Calculate the actual world-space center of the board. The board's
+        // transform position represents the bottom-left corner of the grid, so
+        // we offset by half of the board's width and height to get the center.
+        float halfSize = (gridSize - 1) * tileSize * 0.5f;
+        s_BoardCenter = board.position + new Vector3(halfSize, halfSize, 0f);
     }
 
     private static Vector3 GetBoardCenter()


### PR DESCRIPTION
## Summary
- calculate board's true center before flipping to keep it in place

## Testing
- `dotnet build Puckslide.sln` *(fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898d4f2944c832fb38f52b54420d27e