### PR TITLE
Fix board flip visibility and reset phase 2 pieces

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -47,7 +47,11 @@ public static class BoardFlipper
             if (!puck.transform.IsChildOf(s_BoardTransform))
             {
                 Vector3 offset = puck.transform.position - boardCenter;
-                puck.transform.position = boardCenter - offset;
+                // Mirror the puck across the board center on the X/Y plane but keep its original Z
+                Vector3 newPos = new Vector3(boardCenter.x - offset.x,
+                    boardCenter.y - offset.y,
+                    puck.transform.position.z);
+                puck.transform.position = newPos;
             }
 
             puck.transform.rotation = Quaternion.identity;
@@ -65,7 +69,11 @@ public static class BoardFlipper
             if (!piece.transform.IsChildOf(s_BoardTransform))
             {
                 Vector3 offset = piece.transform.position - boardCenter;
-                piece.transform.position = boardCenter - offset;
+                // Mirror the piece across the board center on the X/Y plane but keep its original Z
+                Vector3 newPos = new Vector3(boardCenter.x - offset.x,
+                    boardCenter.y - offset.y,
+                    piece.transform.position.z);
+                piece.transform.position = newPos;
             }
 
             piece.transform.rotation = Quaternion.identity;

--- a/Puckslide/Assets/Scripts/Phase2Manager.cs
+++ b/Puckslide/Assets/Scripts/Phase2Manager.cs
@@ -7,6 +7,18 @@ public class Phase2Manager : MonoBehaviour
 {
     private void OnEnable()
     {
+        // Clear any lingering pucks from the board
         EventsManager.OnDeletePucks.Invoke(true);
+
+        // Also remove chess pieces left over from previous games
+        foreach (Piece piece in FindObjectsOfType<Piece>())
+        {
+            Tile tile = piece.GetCurrentTile();
+            if (tile != null)
+            {
+                tile.ClearTile();
+            }
+            Destroy(piece.gameObject);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- preserve z-position when mirroring pucks and pieces during board flip so sprites stay visible
- remove leftover chess pieces when starting phase 2

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_6898d775c104832faafa1f983ffc5223