### PR TITLE
Fix phase 2 pieces disappearing

### DIFF
--- a/Puckslide/Assets/Scripts/Phase2Manager.cs
+++ b/Puckslide/Assets/Scripts/Phase2Manager.cs
@@ -7,18 +7,9 @@ public class Phase2Manager : MonoBehaviour
 {
     private void OnEnable()
     {
-        // Clear any lingering pucks from the board
+        // Clear any lingering pucks from the board. Pieces will be spawned
+        // from the last recorded layout by the BoardController, so avoid
+        // destroying them here.
         EventsManager.OnDeletePucks.Invoke(true);
-
-        // Also remove chess pieces left over from previous games
-        foreach (Piece piece in FindObjectsOfType<Piece>())
-        {
-            Tile tile = piece.GetCurrentTile();
-            if (tile != null)
-            {
-                tile.ClearTile();
-            }
-            Destroy(piece.gameObject);
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Don't destroy chess pieces when entering phase 2 so layout persists

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898d97f7b94832f866e7e06165bb7c2