### PR TITLE
Fix board flip offset and add end game cleanup

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -8,25 +8,27 @@ public static class BoardFlipper
     private static int s_GridSize;
     private static float s_TileSize;
 
-    private static Vector3 s_BoardCenter;
-
     public static void SetBoard(Transform board, int gridSize, float tileSize)
     {
         s_BoardTransform = board;
 
         s_GridSize = gridSize;
         s_TileSize = tileSize;
-
-        // Calculate the actual world-space center of the board. The board's
-        // transform position represents the bottom-left corner of the grid, so
-        // we offset by half of the board's width and height to get the center.
-        float halfSize = (gridSize - 1) * tileSize * 0.5f;
-        s_BoardCenter = board.position + new Vector3(halfSize, halfSize, 0f);
     }
 
     private static Vector3 GetBoardCenter()
     {
-        return s_BoardCenter;
+        if (s_BoardTransform == null)
+        {
+            return Vector3.zero;
+        }
+
+        // The board's local origin is at the bottom-left corner of the grid.
+        // We convert the local centre point of the grid into world space every
+        // time we flip so the calculation remains correct even after the
+        // transform has moved or rotated.
+        float halfSize = (s_GridSize - 1) * s_TileSize * 0.5f;
+        return s_BoardTransform.TransformPoint(new Vector3(halfSize, halfSize, 0f));
 
     }
 

--- a/Puckslide/Assets/Scripts/Phase2Manager.cs
+++ b/Puckslide/Assets/Scripts/Phase2Manager.cs
@@ -5,11 +5,35 @@ using UnityEngine;
 
 public class Phase2Manager : MonoBehaviour
 {
+    [SerializeField]
+    private Transform m_BoardTransform;
+    [SerializeField]
+    private int m_GridSize = 8;
+    [SerializeField]
+    private float m_TileSize = 0.383f;
+
     private void OnEnable()
     {
         // Clear any lingering pucks from the board. Pieces will be spawned
         // from the last recorded layout by the BoardController, so avoid
         // destroying them here.
         EventsManager.OnDeletePucks.Invoke(true);
+
+        // Ensure the BoardFlipper knows about the Phase 2 board so pieces
+        // remain aligned when the board is rotated.
+        if (m_BoardTransform != null)
+        {
+            BoardFlipper.SetBoard(m_BoardTransform, m_GridSize, m_TileSize);
+        }
+    }
+
+    public void EndGame()
+    {
+        // Remove all pieces from the board when the player chooses to end
+        // the game.
+        foreach (Piece piece in FindObjectsOfType<Piece>())
+        {
+            Destroy(piece.gameObject);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Recalculate board center each flip to keep pieces aligned after board rotations
- Register phase two board and provide end game cleanup to remove all pieces

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build Puckslide.sln` *(fails: reference assemblies for .NETFramework, Version=v4.7.1 were not found)*


------
https://chatgpt.com/codex/tasks/task_e_6898dcb628d0832fb12a6301294b0053