### PR TITLE
Fix Phase 2 camera orientation

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -102,4 +102,21 @@ public static class BoardFlipper
             }
         }
     }
+
+    public static void FlipCamera()
+    {
+        if (s_BoardTransform == null)
+        {
+            return;
+        }
+
+        s_IsFlipped = !s_IsFlipped;
+
+        Vector3 boardCenter = GetBoardCenter();
+        Camera cam = Camera.main;
+        if (cam != null)
+        {
+            cam.transform.RotateAround(boardCenter, Vector3.forward, 180f);
+        }
+    }
 }

--- a/Puckslide/Assets/Scripts/Chess/BoardController.cs
+++ b/Puckslide/Assets/Scripts/Chess/BoardController.cs
@@ -205,7 +205,7 @@ public class BoardController : MonoBehaviour
                 }
 
                 m_LastMoveWasWhite = m_SelectedPiece.IsWhite();
-                BoardFlipper.Flip();
+                BoardFlipper.FlipCamera();
                 moveMade = true;
             }
 


### PR DESCRIPTION
## Summary
- add method to flip the main camera around the board to swap player perspective
- call the new camera-flip method after each move in Phase 2 so the board stays put

## Testing
- `dotnet build Puckslide.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_6898e8a3300c832fbb87e45cc736d440