### PR TITLE
Fix board flipping pivot to keep board centered

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -31,13 +31,34 @@ public static class BoardFlipper
         // the rotation point.  This works regardless of the board's pivot or
         // orientation.
         Renderer[] renderers = s_BoardTransform.GetComponentsInChildren<Renderer>();
-        if (renderers.Length > 0)
+        Bounds bounds = new Bounds();
+        bool boundsInitialized = false;
+
+        foreach (Renderer r in renderers)
         {
-            Bounds bounds = renderers[0].bounds;
-            for (int i = 1; i < renderers.Length; i++)
+            // Ignore renderers that belong to pieces or pucks. Including them
+            // skews the bounds toward whichever side of the board currently
+            // has more pieces, causing the board to shift in view when
+            // rotated.
+            if (r.GetComponentInParent<PuckController>() != null ||
+                r.GetComponentInParent<Piece>() != null)
             {
-                bounds.Encapsulate(renderers[i].bounds);
+                continue;
             }
+
+            if (!boundsInitialized)
+            {
+                bounds = r.bounds;
+                boundsInitialized = true;
+            }
+            else
+            {
+                bounds.Encapsulate(r.bounds);
+            }
+        }
+
+        if (boundsInitialized)
+        {
             return bounds.center;
         }
 


### PR DESCRIPTION
## Summary
- ignore piece and puck renderers when determining board center
- keep board centered during flip by using only board geometry

## Testing
- `dotnet build Puckslide/Puckslide.sln` *(fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898eef481d0832f9d2580784f420b43