### PR TITLE
Fix board center reference in BoardFlipper

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -111,9 +111,9 @@ public static class BoardFlipper
             if (!puck.transform.IsChildOf(s_BoardTransform))
             {
 
-                Vector3 offset = puck.transform.position - boardCenter;
-                Vector3 newPos = new Vector3(boardCenter.x - offset.x,
-                    boardCenter.y - offset.y,
+                Vector3 offset = puck.transform.position - boardCenterBefore;
+                Vector3 newPos = new Vector3(boardCenterBefore.x - offset.x,
+                    boardCenterBefore.y - offset.y,
 
                     puck.transform.position.z);
                 // Apply the board translation so independent pucks stay aligned.
@@ -136,9 +136,9 @@ public static class BoardFlipper
             if (!piece.transform.IsChildOf(s_BoardTransform))
             {
 
-                Vector3 offset = piece.transform.position - boardCenter;
-                Vector3 newPos = new Vector3(boardCenter.x - offset.x,
-                    boardCenter.y - offset.y,
+                Vector3 offset = piece.transform.position - boardCenterBefore;
+                Vector3 newPos = new Vector3(boardCenterBefore.x - offset.x,
+                    boardCenterBefore.y - offset.y,
 
                     piece.transform.position.z);
                 // Apply the board translation so independent pieces stay aligned.


### PR DESCRIPTION
## Summary
- use board center before rotation when re-aligning independent pucks and pieces

## Testing
- `mcs UnityStubs.cs Puckslide/Assets/Scripts/BoardFlipper.cs` *(fails: Operator `*` cannot be applied to operands of type `UnityEngine.Vector3` and `float`; Type `UnityEngine.Transform` does not contain a definition for `TransformPoint`; Type `UnityEngine.Transform` does not contain a definition for `rotation`; Program `UnityStubs.exe` does not contain a static `Main` method suitable for an entry point)*

------
https://chatgpt.com/codex/tasks/task_e_6898f5d0677c832fa845fea7c694e131