### PR TITLE
Ensure board recenters when flipped

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -95,16 +95,20 @@ public static class BoardFlipper
 
         s_IsFlipped = !s_IsFlipped;
 
-        // Rotate the board around its current centre.
+        // Ensure our cached centre is up to date before rotating.
+        RecalculateBoardCenter();
         Vector3 boardCenterBefore = GetBoardCenter();
         s_BoardTransform.RotateAround(boardCenterBefore, Vector3.forward, 180f);
 
         // After rotation the board's bounds can shift if it has asymmetric
         // renderers (scoreboards, decorations, etc.).  Re‑center the board by
         // translating it so the centre matches its pre‑rotation position.
+        RecalculateBoardCenter();
         Vector3 boardCenterAfter = GetBoardCenter();
         Vector3 boardOffset = boardCenterBefore - boardCenterAfter;
         s_BoardTransform.position += boardOffset;
+        // Update the cached centre again now that the board has been moved.
+        RecalculateBoardCenter();
 
         foreach (PuckController puck in Object.FindObjectsOfType<PuckController>())
         {
@@ -166,6 +170,8 @@ public static class BoardFlipper
 
         s_IsFlipped = !s_IsFlipped;
 
+        // Keep camera rotation centred on the actual board centre.
+        RecalculateBoardCenter();
         Vector3 boardCenter = GetBoardCenter();
         Camera cam = Camera.main;
         if (cam != null)


### PR DESCRIPTION
## Summary
- recompute board center before and after a flip so the board stays in view
- keep camera flips centred on the recalculated board position

## Testing
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build Puckslide.sln` *(fails: reference assemblies for .NETFramework v4.7.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898f8718a70832f8d08064a75104776