### PR TITLE
Flip camera during Phase 2 puck moves

### DIFF
--- a/Puckslide/Assets/Scripts/Phase2Manager.cs
+++ b/Puckslide/Assets/Scripts/Phase2Manager.cs
@@ -12,8 +12,14 @@ public class Phase2Manager : MonoBehaviour
     [SerializeField]
     private float m_TileSize = 0.383f;
 
+    /// <summary>
+    /// Indicates whether Phase 2 gameplay is currently active.
+    /// </summary>
+    public static bool IsPhase2Active { get; private set; }
+
     private void OnEnable()
     {
+        IsPhase2Active = true;
         // Clear any lingering pucks from the board. Pieces will be spawned
         // from the last recorded layout by the BoardController, so avoid
         // destroying them here.
@@ -26,6 +32,11 @@ public class Phase2Manager : MonoBehaviour
             BoardFlipper.SetBoard(m_BoardTransform, m_GridSize, m_TileSize);
             BoardFlipper.SetFlipOffset(new Vector3(0f, -1f, 0f));
         }
+    }
+
+    private void OnDisable()
+    {
+        IsPhase2Active = false;
     }
 
     public void EndGame()

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -173,7 +173,14 @@ public class PuckController : MonoBehaviour
     {
         yield return new WaitForFixedUpdate();
         yield return new WaitUntil(() => m_Rigidbody.velocity.magnitude <= STOP_THRESHOLD);
-        BoardFlipper.Flip();
+        if (Phase2Manager.IsPhase2Active)
+        {
+            BoardFlipper.FlipCamera();
+        }
+        else
+        {
+            BoardFlipper.Flip();
+        }
     }
 
     public Vector2Int CurrentGridPosition { get; private set; } // Store the grid position of this puck


### PR DESCRIPTION
## Summary
- track Phase 2 activity with a static flag in `Phase2Manager`
- flip the camera after puck movement when Phase 2 is active, fall back to board flipping otherwise

## Testing
- `dotnet build Puckslide/Assembly-CSharp.csproj` *(fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_689907cefe48832fa6f442ceffcaf053