### PR TITLE
Center camera before flipping

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -188,6 +188,7 @@ public static class BoardFlipper
         Camera cam = Camera.main;
         if (cam != null)
         {
+            cam.transform.position = new Vector3(boardCenter.x, boardCenter.y, cam.transform.position.z);
             cam.transform.RotateAround(boardCenter, Vector3.forward, 180f);
         }
     }


### PR DESCRIPTION
## Summary
- Recenter camera on board before flip so rotation keeps board in view

## Testing
- `dotnet test Puckslide/Puckslide.sln` *(fails: dotnet: command not found; attempted to install but package unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_689f5dea5858832fb56e40e88d44f15b