### PR TITLE
Set default piece lineup with sticky pawns

### DIFF
--- a/Puckslide/Assets/Scripts/GameSetupManager.cs
+++ b/Puckslide/Assets/Scripts/GameSetupManager.cs
@@ -31,12 +31,12 @@ public class GameSetupManager : MonoBehaviour
     [SerializeField]
     private PieceSetupData[] m_PieceSetup = new PieceSetupData[]
     {
-        new PieceSetupData { Type = ChessPieceType.Pawn,   WhiteCount=0, BlackCount=0, Sticky=false },
-        new PieceSetupData { Type = ChessPieceType.Knight, WhiteCount=0, BlackCount=0, Sticky=false },
-        new PieceSetupData { Type = ChessPieceType.Bishop, WhiteCount=0, BlackCount=0, Sticky=false },
-        new PieceSetupData { Type = ChessPieceType.Rook,   WhiteCount=0, BlackCount=0, Sticky=false },
-        new PieceSetupData { Type = ChessPieceType.Queen,  WhiteCount=0, BlackCount=0, Sticky=false },
-        new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=0, BlackCount=0, Sticky=false },
+        new PieceSetupData { Type = ChessPieceType.Pawn,   WhiteCount=4, BlackCount=4, Sticky=true },
+        new PieceSetupData { Type = ChessPieceType.Knight, WhiteCount=1, BlackCount=1, Sticky=false },
+        new PieceSetupData { Type = ChessPieceType.Bishop, WhiteCount=1, BlackCount=1, Sticky=false },
+        new PieceSetupData { Type = ChessPieceType.Rook,   WhiteCount=1, BlackCount=1, Sticky=false },
+        new PieceSetupData { Type = ChessPieceType.Queen,  WhiteCount=1, BlackCount=1, Sticky=false },
+        new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=1, BlackCount=1, Sticky=false },
     };
 
     [SerializeField]
@@ -52,12 +52,12 @@ public class GameSetupManager : MonoBehaviour
 
         m_PieceSetup = new PieceSetupData[]
         {
-            new PieceSetupData { Type = ChessPieceType.Pawn,   WhiteCount=0, BlackCount=0, Sticky=false },
-            new PieceSetupData { Type = ChessPieceType.Knight, WhiteCount=0, BlackCount=0, Sticky=false },
-            new PieceSetupData { Type = ChessPieceType.Bishop, WhiteCount=0, BlackCount=0, Sticky=false },
-            new PieceSetupData { Type = ChessPieceType.Rook,   WhiteCount=0, BlackCount=0, Sticky=false },
-            new PieceSetupData { Type = ChessPieceType.Queen,  WhiteCount=0, BlackCount=0, Sticky=false },
-            new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=0, BlackCount=0, Sticky=false },
+            new PieceSetupData { Type = ChessPieceType.Pawn,   WhiteCount=4, BlackCount=4, Sticky=true },
+            new PieceSetupData { Type = ChessPieceType.Knight, WhiteCount=1, BlackCount=1, Sticky=false },
+            new PieceSetupData { Type = ChessPieceType.Bishop, WhiteCount=1, BlackCount=1, Sticky=false },
+            new PieceSetupData { Type = ChessPieceType.Rook,   WhiteCount=1, BlackCount=1, Sticky=false },
+            new PieceSetupData { Type = ChessPieceType.Queen,  WhiteCount=1, BlackCount=1, Sticky=false },
+            new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=1, BlackCount=1, Sticky=false },
         };
     }
 
@@ -122,6 +122,34 @@ public class GameSetupManager : MonoBehaviour
                 return;
             }
         }
+    }
+
+    public int GetCount(ChessPieceType pieceType, bool isWhite)
+    {
+        for (int i = 0; i < m_PieceSetup.Length; i++)
+        {
+            if (m_PieceSetup[i].Type == pieceType)
+            {
+                return isWhite ? m_PieceSetup[i].WhiteCount : m_PieceSetup[i].BlackCount;
+            }
+        }
+
+        Debug.LogWarning($"No PieceSetupData found for {pieceType}");
+        return 0;
+    }
+
+    public bool GetSticky(ChessPieceType pieceType)
+    {
+        for (int i = 0; i < m_PieceSetup.Length; i++)
+        {
+            if (m_PieceSetup[i].Type == pieceType)
+            {
+                return m_PieceSetup[i].Sticky;
+            }
+        }
+
+        Debug.LogWarning($"No PieceSetupData found for {pieceType}");
+        return false;
     }
 
 

--- a/Puckslide/Assets/Scripts/UI/PieceSetupCounter.cs
+++ b/Puckslide/Assets/Scripts/UI/PieceSetupCounter.cs
@@ -24,7 +24,7 @@ public class PieceSetupCounter : MonoBehaviour
 
     private void OnEnable()
     {
-        m_CurrentCount = 0;
+        m_CurrentCount = m_GameSetupManager.GetCount(m_ChessPieceType, m_IsWhiteCounter);
         m_TextMeshProUGUI.text = $"{m_CurrentCount}";
         m_MinusButton.onClick.AddListener(MinusPressed);
         m_PlusButton.onClick.AddListener(PlusPressed);

--- a/Puckslide/Assets/Scripts/UI/StickySetup.cs
+++ b/Puckslide/Assets/Scripts/UI/StickySetup.cs
@@ -16,7 +16,7 @@ public class StickySetup : MonoBehaviour
 
     private void OnEnable()
     {
-        m_StickyToggle.isOn = false;
+        m_StickyToggle.isOn = m_GameSetupManager.GetSticky(m_ChessPieceType);
         m_StickyToggle.onValueChanged.AddListener(OnToggle);
     }
     


### PR DESCRIPTION
## Summary
- initialize piece setup to four sticky pawns and one of each other piece for both colors
- expose getters for piece counts and stickiness and update setup UI to use them

## Testing
- `dotnet test Puckslide.sln` *(no tests found)*
- `dotnet build Puckslide.sln` *(fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f626b5e4c832f9b51bceb23ff90a5