### PR TITLE
Rotate pucks upright in Phase 2 camera flip

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -198,5 +198,15 @@ public static class BoardFlipper
 
             cam.transform.position = new Vector3(boardCenter.x + offset.x, boardCenter.y + offset.y, cam.transform.position.z);
         }
+
+        // Ensure pucks remain upright relative to the player's view when the
+        // camera is flipped. Without this, sprites appear upside down in the
+        // reversed board state of Phase 2.
+        foreach (PuckController puck in Object.FindObjectsOfType<PuckController>())
+        {
+            puck.transform.rotation = s_IsFlipped
+                ? Quaternion.Euler(0f, 0f, 180f)
+                : Quaternion.identity;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- keep pucks upright when camera reverses during Phase 2

## Testing
- `apt-get update`
- `apt-get install -y mono-devel`
- `xbuild Puckslide.sln` *(fails: Invalid -langversion option `7.3`)*

------
https://chatgpt.com/codex/tasks/task_e_689f65757100832fa4b7e0e0d24bc40c