### PR TITLE
Rotate pucks upright during Phase 2 camera flip

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -198,5 +198,14 @@ public static class BoardFlipper
 
             cam.transform.position = new Vector3(boardCenter.x + offset.x, boardCenter.y + offset.y, cam.transform.position.z);
         }
+
+        // Ensure pucks remain upright relative to the player's view when the
+        // camera is flipped. Rotating them by 180° each time we flip the camera
+        // preserves their original orientation without relying on a hardcoded
+        // absolute rotation.
+        foreach (PuckController puck in Object.FindObjectsOfType<PuckController>())
+        {
+            puck.transform.Rotate(0f, 0f, 180f, Space.Self);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- rotate pucks 180° whenever the camera flips so sprites stay upright in Phase 2

## Testing
- `apt-get update`
- `apt-get install -y mono-devel`
- `apt-get install -y msbuild` *(fails: Unable to locate package)*
- `xbuild Puckslide/Puckslide.sln` *(fails: Invalid -langversion option `7.3`)*

------
https://chatgpt.com/codex/tasks/task_e_689f65757100832fa4b7e0e0d24bc40c