### PR TITLE
Limit puck launch strength

### DIFF
--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -153,8 +153,9 @@ public class PuckController : MonoBehaviour
 
         Vector3 dragEndPos = m_Camera.ScreenToWorldPoint(Input.mousePosition);
         Vector2 dragVector = (m_DragStartPos - dragEndPos);
-
-        float power = 5f;
+        const float maxDragDistance = 3f;
+        dragVector = Vector2.ClampMagnitude(dragVector, maxDragDistance);
+        float power = 3f;
         m_Rigidbody.bodyType = RigidbodyType2D.Dynamic;
         m_Rigidbody.AddForce(dragVector * power, ForceMode2D.Impulse);
 


### PR DESCRIPTION
## Summary
- clamp drag distance and lower power to curb overly strong puck shots

## Testing
- `dotnet build Puckslide/Puckslide.sln` *(fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0630c9064832f8ff09dfbb0b2bcd9