### PR TITLE
Add red dotted trajectory preview

### DIFF
--- a/Puckslide/Assets/Scripts/PuckFriction.cs
+++ b/Puckslide/Assets/Scripts/PuckFriction.cs
@@ -19,6 +19,6 @@ public class PuckFriction : MonoBehaviour
             m_Rigidbody.velocity = Vector2.zero;
         }
     }
-    
-    
+
+    public float Friction => m_Friction;
 }


### PR DESCRIPTION
## Summary
- Add trajectory line renderer with red dotted material and predicted path simulation
- Expose friction value for trajectory calculations

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a0702a09d4832fbe32b25d72482dcc