### PR TITLE
Add turn indicator and enforce turn order

### DIFF
--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -42,7 +42,7 @@ public class PuckController : MonoBehaviour
 
     [SerializeField]
     private float m_MaxLineWidth = 0.3f;
-    private static bool? s_LastMoveWasWhite = null;
+    private static bool s_IsWhiteTurn = true;
     private bool m_IsSelected;
 
     private void Awake()
@@ -150,7 +150,7 @@ public class PuckController : MonoBehaviour
 
     private void OnMouseDown()
     {
-        if (s_LastMoveWasWhite != null && IsWhitePiece == s_LastMoveWasWhite.Value)
+        if (IsWhitePiece != s_IsWhiteTurn)
         {
             m_IsSelected = false;
             return;
@@ -262,7 +262,8 @@ public class PuckController : MonoBehaviour
             m_TrajectoryRenderer.enabled = false;
         }
 
-        s_LastMoveWasWhite = IsWhitePiece;
+        s_IsWhiteTurn = !s_IsWhiteTurn;
+        EventsManager.OnTurnChanged.Invoke(s_IsWhiteTurn);
         m_IsSelected = false;
 
         StartCoroutine(WaitForPuckStopped());
@@ -329,9 +330,12 @@ public class PuckController : MonoBehaviour
 
     public bool IsWhitePiece => (int)ChessPiece >= 6;
 
+    public static bool IsWhiteTurn => s_IsWhiteTurn;
+
     public static void ResetTurnOrder()
     {
-        s_LastMoveWasWhite = false; // Start with white's turn
+        s_IsWhiteTurn = true; // Start with white's turn
+        EventsManager.OnTurnChanged.Invoke(s_IsWhiteTurn);
     }
 
     public void UpdateGridPosition(float tileSize, Vector2 gridOrigin)

--- a/Puckslide/Assets/Scripts/UI/Phase1PieceButton.cs
+++ b/Puckslide/Assets/Scripts/UI/Phase1PieceButton.cs
@@ -49,7 +49,15 @@ public class Phase1PieceButton : MonoBehaviour
             return;
         }
 
-        PuckController puckController = Instantiate(m_PuckPrefab, m_PuckSpawnTransform.position, Quaternion.identity).GetComponent<PuckController>();
+        if (PuckController.IsWhiteTurn != m_IsWhite)
+        {
+            return;
+        }
+
+        float diameter = m_PuckPrefab.GetComponent<CircleCollider2D>().radius * 2f * m_PuckPrefab.transform.localScale.x;
+        Vector3 spawnPos = m_PuckSpawnTransform.position + m_PuckSpawnTransform.up * diameter;
+
+        PuckController puckController = Instantiate(m_PuckPrefab, spawnPos, Quaternion.identity).GetComponent<PuckController>();
         puckController.Init(m_ChessPieceType, m_IsSticky, m_IsWhite);
         m_PieceCount--;
         m_PieceCountText.text = $"X {m_PieceCount}";

--- a/Puckslide/Assets/Scripts/UI/TurnIndicator.cs
+++ b/Puckslide/Assets/Scripts/UI/TurnIndicator.cs
@@ -1,0 +1,26 @@
+using TMPro;
+using UnityEngine;
+
+public class TurnIndicator : MonoBehaviour
+{
+    [SerializeField]
+    private TextMeshProUGUI m_Text;
+
+    private void OnEnable()
+    {
+        EventsManager.OnTurnChanged.AddListener(OnTurnChanged, true);
+    }
+
+    private void OnDisable()
+    {
+        EventsManager.OnTurnChanged.RemoveListener(OnTurnChanged);
+    }
+
+    private void OnTurnChanged(bool isWhiteTurn)
+    {
+        if (m_Text != null)
+        {
+            m_Text.text = isWhiteTurn ? "White's turn" : "Black's turn";
+        }
+    }
+}

--- a/Puckslide/Assets/Scripts/UI/TurnIndicator.cs.meta
+++ b/Puckslide/Assets/Scripts/UI/TurnIndicator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 33a1bd02c00b4482abee609e8475d5f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Puckslide/Assets/Scripts/Util/EventsManager.cs
+++ b/Puckslide/Assets/Scripts/Util/EventsManager.cs
@@ -10,6 +10,7 @@ public static class EventsManager
     public static readonly Evt<Dictionary<Vector2Int, ChessPiece>> OnBoardLayout = new Evt<Dictionary<Vector2Int, ChessPiece>>();
     public static readonly Evt<Rigidbody2D> OnPuckSpawned = new Evt<Rigidbody2D>();
     public static readonly Evt<Rigidbody2D> OnPuckDespawned = new Evt<Rigidbody2D>();
+    public static readonly Evt<bool> OnTurnChanged = new Evt<bool>(true);
 }
 
 


### PR DESCRIPTION
## Summary
- add turn change event and indicator UI to show whose turn it is
- restrict puck selection and spawning to the active color, starting with white
- shift spawn position forward by one puck diameter for better launch pad placement

## Testing
- `dotnet build Puckslide/Puckslide.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0903c8520832fb7849b080020b6bf