### PR TITLE
Hook up TurnIndicator UI text

### DIFF
--- a/Puckslide/Assets/Scenes/Main.unity
+++ b/Puckslide/Assets/Scenes/Main.unity
@@ -133,8 +133,9 @@ GameObject:
   - component: {fileID: 24850033}
   - component: {fileID: 24850035}
   - component: {fileID: 24850034}
+  - component: {fileID: 24850036}
   m_Layer: 5
-  m_Name: Text (TMP)
+  m_Name: Turn Text
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -179,7 +180,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Sticky piece?
+  m_text: White's turn
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -256,6 +257,19 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 24850032}
   m_CullTransparentMesh: 1
+--- !u!114 &24850036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 24850032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 33a1bd02c00b4482abee609e8475d5f8, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Text: {fileID: 24850034}
 --- !u!1 &48382079
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- attach TurnIndicator script to a TextMeshPro object for displaying turn information
- initialize the UI text to show "White's turn"

## Testing
- `dotnet test Puckslide.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a093683ee0832fb5a3f9f1563d30d4