### PR TITLE
Reduce puck shot strength by 20%

### DIFF
--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -35,7 +35,8 @@ public class PuckController : MonoBehaviour
 
     private const float STOP_THRESHOLD = 0.05f;
     [SerializeField]
-    private float m_MaxShootForce = 12f;
+    // Reduced max shoot force by 20% to limit shot strength
+    private float m_MaxShootForce = 9.6f;
 
     [SerializeField]
     private float m_MinLineWidth = 0.05f;


### PR DESCRIPTION
## Summary
- Limit puck shooting strength by reducing maximum force constant 20%

## Testing
- `mcs Assets/Scripts/PuckController.cs` *(fails: UnityEngine references missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a095b8fca4832f8a5df7354de2bf37