### PR TITLE
Refactor drag and trajectory handling in puck controller

### DIFF
--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -195,19 +195,27 @@ public class PuckController : MonoBehaviour
             return;
         }
 
+        Vector3 dragPos = m_Camera.ScreenToWorldPoint(Input.mousePosition);
+        dragPos.z = 0;
+
+        Vector3 puckCenter = transform.position;
+        puckCenter.z = 0;
+
+        Vector3 offset = dragPos - puckCenter;
+        Vector3 clampedOffset = Vector3.ClampMagnitude(offset, m_MaxDragDistance);
+        Vector3 endPos = puckCenter + clampedOffset;
+
+        float powerRatio = clampedOffset.magnitude / m_MaxDragDistance;
+        Vector3 direction = (puckCenter - endPos).normalized;
+        Vector3 dragVector = direction * (powerRatio * m_MaxShootForce);
+
+        if (m_TrajectoryRenderer != null && m_TrajectoryRenderer.enabled)
+        {
+            UpdateTrajectory(dragVector);
+        }
+
         if (m_LineRenderer != null && m_LineRenderer.enabled)
         {
-            Vector3 dragPos = m_Camera.ScreenToWorldPoint(Input.mousePosition);
-            dragPos.z = 0;
-
-            Vector3 puckCenter = transform.position;
-            puckCenter.z = 0;
-
-            Vector3 offset = dragPos - puckCenter;
-            Vector3 clampedOffset = Vector3.ClampMagnitude(offset, m_MaxDragDistance);
-            Vector3 endPos = puckCenter + clampedOffset;
-
-            float powerRatio = clampedOffset.magnitude / m_MaxDragDistance;
             Color powerColor = Color.Lerp(Color.green, Color.red, powerRatio);
             m_LineRenderer.startColor = powerColor;
             m_LineRenderer.endColor = powerColor;
@@ -218,13 +226,6 @@ public class PuckController : MonoBehaviour
             float endWidth = Mathf.Lerp(m_MinLineWidth, m_MaxLineWidth, powerRatio);
             m_LineRenderer.startWidth = m_MinLineWidth;
             m_LineRenderer.endWidth = endWidth;
-
-            Vector3 direction = (puckCenter - endPos).normalized;
-            Vector3 dragVector = direction * (powerRatio * m_MaxShootForce);
-            if (m_TrajectoryRenderer != null && m_TrajectoryRenderer.enabled)
-            {
-                UpdateTrajectory(dragVector);
-            }
 
             DrawDragLimitCircle(puckCenter);
         }


### PR DESCRIPTION
## Summary
- Compute drag vector and power metrics outside of the line-rendering block
- Update trajectory whenever its renderer is enabled
- Keep drag line drawing conditional on the line renderer

## Testing
- `dotnet build Puckslide.sln` *(fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09699f194832f989ff8b9e1bd6b90