### PR TITLE
Ensure trajectory renderer uses minimum width

### DIFF
--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -66,6 +66,8 @@ public class PuckController : MonoBehaviour
             m_TrajectoryRenderer.endColor = Color.red;
             m_TrajectoryRenderer.textureMode = LineTextureMode.Tile;
             m_TrajectoryRenderer.positionCount = 0;
+            m_TrajectoryRenderer.startWidth = m_MinLineWidth;
+            m_TrajectoryRenderer.endWidth = m_MinLineWidth;
 
             Texture2D tex = new Texture2D(2, 1);
             tex.SetPixel(0, 0, Color.white);
@@ -186,6 +188,8 @@ public class PuckController : MonoBehaviour
         {
             m_TrajectoryRenderer.enabled = true;
             m_TrajectoryRenderer.positionCount = 0;
+            m_TrajectoryRenderer.startWidth = m_MinLineWidth;
+            m_TrajectoryRenderer.endWidth = m_MinLineWidth;
         }
     }
 


### PR DESCRIPTION
## Summary
- Set trajectory line renderer width to the minimum line width on initialization
- Apply minimum width when enabling trajectory rendering during selection

## Testing
- `dotnet test Puckslide/Puckslide.sln` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a098642f24832fa1dc7c91020c5950