### PR TITLE
Ensure line renderer on PuckController

### DIFF
--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using UnityEngine;
 
+[RequireComponent(typeof(LineRenderer))]
 public class PuckController : MonoBehaviour
 {
     [SerializeField]
@@ -50,6 +51,11 @@ public class PuckController : MonoBehaviour
     {
         m_Camera = Camera.main;
         m_Rigidbody.freezeRotation = true;
+        m_TrajectoryRenderer ??= GetComponent<LineRenderer>();
+        if (m_TrajectoryRenderer == null)
+        {
+            Debug.LogWarning("PuckController requires a LineRenderer component.", this);
+        }
         m_PuckFriction = GetComponent<PuckFriction>();
         m_Collider = GetComponent<CircleCollider2D>();
 


### PR DESCRIPTION
## Summary
- require a LineRenderer on PuckController
- auto-fetch the LineRenderer and warn if missing

## Testing
- `dotnet test Puckslide/Puckslide.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a09b154e50832fa36d0786976682e2