### PR TITLE
Use world-space TextMeshPro turn indicator

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -89,9 +89,14 @@ public static class BoardFlipper
         s_BoardCenter = s_BoardTransform.TransformPoint(new Vector3(halfSize, halfSize, 0f));
     }
 
-    private static Vector3 GetBoardCenter()
+    public static Vector3 GetBoardCenter()
     {
         return s_BoardCenter;
+    }
+
+    public static Transform GetBoardTransform()
+    {
+        return s_BoardTransform;
     }
 
     public static void Flip()

--- a/Puckslide/Assets/Scripts/UI/TurnIndicator.cs
+++ b/Puckslide/Assets/Scripts/UI/TurnIndicator.cs
@@ -4,7 +4,29 @@ using UnityEngine;
 public class TurnIndicator : MonoBehaviour
 {
     [SerializeField]
-    private TextMeshProUGUI m_Text;
+    private TextMeshPro m_Text;
+
+    [SerializeField]
+    private Vector3 m_Offset = new Vector3(0f, 0f, -0.1f);
+
+    private void Awake()
+    {
+        if (m_Text == null)
+        {
+            m_Text = GetComponent<TextMeshPro>();
+        }
+    }
+
+    private void Start()
+    {
+        Transform board = BoardFlipper.GetBoardTransform();
+        if (board != null)
+        {
+            Vector3 center = BoardFlipper.GetBoardCenter();
+            transform.position = center + m_Offset;
+            transform.SetParent(board, true);
+        }
+    }
 
     private void OnEnable()
     {


### PR DESCRIPTION
## Summary
- display turn text with a 3D TextMeshPro object in world space
- expose board transform and center helpers for positioning

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ab0c186c832f9f6cd7dbef623631