### PR TITLE
Keep chess piece sprites upright when board flips

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -209,5 +209,15 @@ public static class BoardFlipper
             puck.transform.Rotate(0f, 0f, 180f, Space.Self);
 
         }
+
+        // Pieces are implemented as flat sprites on pucks. When the camera flips
+        // to show the opposite player's perspective we need to rotate these
+        // sprites as well, otherwise the chess piece images appear upside down.
+        // Rotating each Piece by 180° keeps the artwork facing "up" relative to
+        // the camera just like we do for the pucks themselves.
+        foreach (Piece piece in Object.FindObjectsOfType<Piece>())
+        {
+            piece.transform.Rotate(0f, 0f, 180f, Space.Self);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Rotate each chess `Piece` 180° whenever the camera flips so their sprites stay upright for the current player

## Testing
- `xbuild Puckslide/Assembly-CSharp.csproj` *(fails: CSC error CS1617 invalid -langversion option `7.3`)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ac7b2380832f99bbca458addd918