### PR TITLE
Fix puck reshoot and board boundary update

### DIFF
--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -393,7 +393,6 @@ public class PuckController : MonoBehaviour
         if (reachedBoard)
         {
             s_IsWhiteTurn = !s_IsWhiteTurn;
-            EventsManager.OnTurnChanged.Invoke(s_IsWhiteTurn);
             if (Phase2Manager.IsPhase2Active)
             {
                 BoardFlipper.FlipCamera();
@@ -402,6 +401,7 @@ public class PuckController : MonoBehaviour
             {
                 BoardFlipper.Flip();
             }
+            EventsManager.OnTurnChanged.Invoke(s_IsWhiteTurn);
         }
         else
         {
@@ -409,6 +409,7 @@ public class PuckController : MonoBehaviour
             // Shot stopped before reaching the board—reset for another try
 
             m_Rigidbody.position = m_StartPosition;
+            transform.position = m_StartPosition;
             m_Rigidbody.velocity = Vector2.zero;
             m_Rigidbody.angularVelocity = 0f;
             transform.rotation = Quaternion.identity;


### PR DESCRIPTION
## Summary
- Ensure turn-change event fires after board flip so entry lines recalc with new orientation
- Reset puck transform as well as Rigidbody when shot stops before board to maintain launch position

## Testing
- `dotnet build Puckslide.sln` *(fails: reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bb034624832fa33fd26a916bd48f