### PR TITLE
Recompute puck entry bounds after board setup

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -1,7 +1,10 @@
+using System;
 using UnityEngine;
 
 public static class BoardFlipper
 {
+    public static event Action OnBoardSet;
+
     private static bool s_IsFlipped = false;
     private static Transform s_BoardTransform;
 
@@ -20,6 +23,7 @@ public static class BoardFlipper
         s_TileSize = tileSize;
 
         RecalculateBoardCenter();
+        OnBoardSet?.Invoke();
     }
 
     public static void SetFlipOffset(Vector3 offset)

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -96,16 +96,23 @@ public class PuckController : MonoBehaviour
             m_TrajectoryRenderer.material = mat;
         }
 
-
-        UpdateBoardEntryLines();
         m_StartPosition = transform.position;
+    }
+
+    private void Start()
+    {
+        UpdateBoardEntryLines();
     }
 
     // Recalculate the entry lines at the top and bottom of the board.
     public void UpdateBoardEntryLines()
     {
         Transform board = BoardFlipper.GetBoardTransform();
-        Tile[] tiles = board != null ? board.GetComponentsInChildren<Tile>() : Array.Empty<Tile>();
+        if (board == null)
+        {
+            return;
+        }
+        Tile[] tiles = board.GetComponentsInChildren<Tile>();
         if (tiles.Length == 0)
         {
             Debug.LogWarning("PuckController could not locate any board tiles to determine board entry.", this);
@@ -148,6 +155,7 @@ public class PuckController : MonoBehaviour
     {
         EventsManager.OnDeletePucks.AddListener(OnDelete);
         EventsManager.OnTurnChanged.AddListener(OnTurnChanged, true);
+        BoardFlipper.OnBoardSet += UpdateBoardEntryLines;
         EventsManager.OnPuckSpawned.Invoke(m_Rigidbody);
     }
 
@@ -155,6 +163,7 @@ public class PuckController : MonoBehaviour
     {
         EventsManager.OnDeletePucks.RemoveListener(OnDelete);
         EventsManager.OnTurnChanged.RemoveListener(OnTurnChanged);
+        BoardFlipper.OnBoardSet -= UpdateBoardEntryLines;
         EventsManager.OnPuckDespawned.Invoke(m_Rigidbody);
         if (s_ActivePuck == this)
         {


### PR DESCRIPTION
## Summary
- Defer board entry line calculation until `Start` so pucks initialize after the board exists
- Expose `BoardFlipper.OnBoardSet` event and subscribe in `PuckController` to recalculate entry bounds when the board changes

## Testing
- `dotnet build` *(fails: command not found)*
- `sudo apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c71af9cc832fb847a0cfea8b00d0