### PR TITLE
Use board bounds to validate puck entry

### DIFF
--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -48,6 +48,7 @@ public class PuckController : MonoBehaviour
     private static PuckController s_ActivePuck;
     private bool m_IsSelected;
 
+    private Collider2D m_BoardBounds;
     // Entry lines for both sides of the board.
     private float m_BottomEntryY;
     private float m_TopEntryY;
@@ -110,8 +111,10 @@ public class PuckController : MonoBehaviour
         Transform board = BoardFlipper.GetBoardTransform();
         if (board == null)
         {
+            m_BoardBounds = null;
             return;
         }
+        m_BoardBounds = board.GetComponentInChildren<Collider2D>();
         Tile[] tiles = board.GetComponentsInChildren<Tile>();
         if (tiles.Length == 0)
         {
@@ -174,6 +177,11 @@ public class PuckController : MonoBehaviour
     private void OnTurnChanged(bool _)
     {
         UpdateBoardEntryLines();
+        Transform board = BoardFlipper.GetBoardTransform();
+        if (board != null)
+        {
+            m_BoardBounds = board.GetComponentInChildren<Collider2D>();
+        }
     }
 
     private void OnDelete(bool delete)
@@ -404,7 +412,7 @@ public class PuckController : MonoBehaviour
         yield return new WaitForFixedUpdate();
         yield return new WaitUntil(() => m_Rigidbody.velocity.magnitude <= STOP_THRESHOLD);
 
-        bool reachedBoard = transform.position.y >= m_BottomEntryY && transform.position.y <= m_TopEntryY;
+        bool reachedBoard = m_BoardBounds != null && m_BoardBounds.bounds.Contains(m_Rigidbody.worldCenterOfMass);
 
         if (reachedBoard)
         {


### PR DESCRIPTION
## Summary
- track board edge collider and monitor puck entry via bounds containment
- refresh boundary collider reference each turn change
- reset pucks unless their center crosses into the board bounds

## Testing
- `dotnet test` *(fails: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c814b3e8832faaa86c2895c8dc3c