### PR TITLE
Replace unsupported C# constructs

### DIFF
--- a/Puckslide/Assembly-CSharp.csproj
+++ b/Puckslide/Assembly-CSharp.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Generated file, do not modify, your changes will be overwritten (use AssetPostprocessor.OnGeneratedCSProject) -->
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/Puckslide/Assets/Scripts/Chess/Piece.cs
+++ b/Puckslide/Assets/Scripts/Chess/Piece.cs
@@ -45,6 +45,6 @@ public class Piece : MonoBehaviour
 
     public bool IsPawn()
     {
-        return m_ChessPiece is ChessPiece.B_Pawn or ChessPiece.W_Pawn;
+        return m_ChessPiece == ChessPiece.B_Pawn || m_ChessPiece == ChessPiece.W_Pawn;
     }
 }

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -60,7 +60,10 @@ public class PuckController : MonoBehaviour
     {
         m_Camera = Camera.main;
         m_Rigidbody.freezeRotation = true;
-        m_TrajectoryRenderer ??= GetComponent<LineRenderer>();
+        if (m_TrajectoryRenderer == null)
+        {
+            m_TrajectoryRenderer = GetComponent<LineRenderer>();
+        }
         if (m_TrajectoryRenderer == null)
         {
             Debug.LogWarning("PuckController requires a LineRenderer component.", this);


### PR DESCRIPTION
## Summary
- allow newer compiler by targeting latest C# version in project
- remove null-coalescing assignment in PuckController
- replace pattern matching with equality check in Piece

## Testing
- `xbuild Puckslide.sln` *(fails: missing UnityEngine and related assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ccb2e1a4832f8b6d7a5fc72863c2