### PR TITLE
Include BoardFlipper and TurnIndicator scripts

### DIFF
--- a/Puckslide/Assembly-CSharp.csproj
+++ b/Puckslide/Assembly-CSharp.csproj
@@ -71,6 +71,8 @@
     <Compile Include="Assets\Scripts\Util\EventsManager.cs" />
     <Compile Include="Assets\Scripts\OneWayWall.cs" />
     <Compile Include="Assets\Scripts\Chess\PromotionPanel.cs" />
+    <Compile Include="Assets\Scripts\BoardFlipper.cs" />
+    <Compile Include="Assets\Scripts\UI\TurnIndicator.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\TextMesh Pro\Shaders\TMPro.cginc" />


### PR DESCRIPTION
## Summary
- ensure BoardFlipper.cs and TurnIndicator.cs are compiled by Assembly-CSharp project

## Testing
- `dotnet build Puckslide.sln` *(fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a8f0d3f0832f93c72b3c3a747b92