### PR TITLE
Make king sticky by default in game setup

### DIFF
--- a/Puckslide/Assets/Scripts/GameSetupManager.cs
+++ b/Puckslide/Assets/Scripts/GameSetupManager.cs
@@ -36,7 +36,7 @@ public class GameSetupManager : MonoBehaviour
         new PieceSetupData { Type = ChessPieceType.Bishop, WhiteCount=1, BlackCount=1, Sticky=false },
         new PieceSetupData { Type = ChessPieceType.Rook,   WhiteCount=1, BlackCount=1, Sticky=false },
         new PieceSetupData { Type = ChessPieceType.Queen,  WhiteCount=1, BlackCount=1, Sticky=false },
-        new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=1, BlackCount=1, Sticky=false },
+        new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=1, BlackCount=1, Sticky=true },
     };
 
     [SerializeField]
@@ -57,7 +57,7 @@ public class GameSetupManager : MonoBehaviour
             new PieceSetupData { Type = ChessPieceType.Bishop, WhiteCount=1, BlackCount=1, Sticky=false },
             new PieceSetupData { Type = ChessPieceType.Rook,   WhiteCount=1, BlackCount=1, Sticky=false },
             new PieceSetupData { Type = ChessPieceType.Queen,  WhiteCount=1, BlackCount=1, Sticky=false },
-            new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=1, BlackCount=1, Sticky=false },
+            new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=1, BlackCount=1, Sticky=true },
         };
     }
 


### PR DESCRIPTION
## Summary
- Mark king as sticky in default piece setup and reset so pawns and king are sticky

## Testing
- `dotnet build Puckslide.sln` *(fails: reference assemblies for .NETFramework,Version=v4.7.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e3a73b28832f93a65ec42230b193