### PR TITLE
chore: enable latest C# language version

### DIFF
--- a/Puckslide/Assembly-CSharp.csproj
+++ b/Puckslide/Assembly-CSharp.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Generated file, do not modify, your changes will be overwritten (use AssetPostprocessor.OnGeneratedCSProject) -->
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
## Summary
- update LangVersion to `latest` so Unity can compile C# features such as pattern matching and null-coalescing assignment

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a213257a78832fa73d0e932058a394