### PR TITLE
fix: revert C# features for 7.3

### DIFF
--- a/Puckslide/Assets/Scripts/Chess/Piece.cs
+++ b/Puckslide/Assets/Scripts/Chess/Piece.cs
@@ -45,6 +45,6 @@ public class Piece : MonoBehaviour
 
     public bool IsPawn()
     {
-        return m_ChessPiece is ChessPiece.B_Pawn or ChessPiece.W_Pawn;
+        return m_ChessPiece == ChessPiece.B_Pawn || m_ChessPiece == ChessPiece.W_Pawn;
     }
 }

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -61,7 +61,11 @@ public class PuckController : MonoBehaviour
     {
         m_Camera = Camera.main;
         m_Rigidbody.freezeRotation = true;
-        m_TrajectoryRenderer ??= GetComponent<LineRenderer>();
+        if (m_TrajectoryRenderer == null)
+        {
+            m_TrajectoryRenderer = GetComponent<LineRenderer>();
+        }
+
         if (m_TrajectoryRenderer == null)
         {
             Debug.LogWarning("PuckController requires a LineRenderer component.", this);


### PR DESCRIPTION
## Summary
- set LangVersion to 7.3
- replace modern C# syntax in `PuckController` and `Piece` with 7.3-compatible constructs

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `apt-get update` *(warning: some index files failed to download)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a213257a78832fa73d0e932058a394