### PR TITLE
Include PuckAimLine script in Assembly-CSharp project

### DIFF
--- a/Puckslide/Assembly-CSharp.csproj
+++ b/Puckslide/Assembly-CSharp.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <Compile Include="Assets\Scripts\Phase2Manager.cs" />
     <Compile Include="Assets\Scripts\PuckController.cs" />
+    <Compile Include="Assets\Scripts\PuckAimLine.cs" />
     <Compile Include="Assets\Scripts\Chess\CapturedPieceUi.cs" />
     <Compile Include="Assets\Scripts\PuckFriction.cs" />
     <Compile Include="Assets\Scripts\Chess\Tile.cs" />


### PR DESCRIPTION
## Summary
- ensure PuckAimLine.cs is referenced in Assembly-CSharp.csproj so Unity will compile it

## Testing
- `dotnet build Assembly-CSharp.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2186b225c832fb219a3b6db480429