### PR TITLE
Make king sticky by default

### DIFF
--- a/Puckslide/Assets/Scripts/GameSetupManager.cs
+++ b/Puckslide/Assets/Scripts/GameSetupManager.cs
@@ -36,7 +36,7 @@ public class GameSetupManager : MonoBehaviour
         new PieceSetupData { Type = ChessPieceType.Bishop, WhiteCount=1, BlackCount=1, Sticky=false },
         new PieceSetupData { Type = ChessPieceType.Rook,   WhiteCount=1, BlackCount=1, Sticky=false },
         new PieceSetupData { Type = ChessPieceType.Queen,  WhiteCount=1, BlackCount=1, Sticky=false },
-        new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=1, BlackCount=1, Sticky=false },
+        new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=1, BlackCount=1, Sticky=true },
     };
 
     [SerializeField]
@@ -57,7 +57,7 @@ public class GameSetupManager : MonoBehaviour
             new PieceSetupData { Type = ChessPieceType.Bishop, WhiteCount=1, BlackCount=1, Sticky=false },
             new PieceSetupData { Type = ChessPieceType.Rook,   WhiteCount=1, BlackCount=1, Sticky=false },
             new PieceSetupData { Type = ChessPieceType.Queen,  WhiteCount=1, BlackCount=1, Sticky=false },
-            new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=1, BlackCount=1, Sticky=false },
+            new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=1, BlackCount=1, Sticky=true },
         };
     }
 


### PR DESCRIPTION
## Summary
- Make the king piece sticky by default by setting its sticky flag in both default and runtime piece setups

## Testing
- `dotnet build Puckslide.sln` *(fails: reference assemblies for .NETFramework v4.7.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a24d360788832f97dc1555ba90b8bd