### PR TITLE
Add board trigger and puck detection

### DIFF
--- a/Puckslide/Assets/Scripts/BoardFlipper.cs
+++ b/Puckslide/Assets/Scripts/BoardFlipper.cs
@@ -19,12 +19,42 @@ public static class BoardFlipper
         s_GridSize = gridSize;
         s_TileSize = tileSize;
 
+        EnsureBoardTrigger();
+
         RecalculateBoardCenter();
     }
 
     public static void SetFlipOffset(Vector3 offset)
     {
         s_FlipOffset = offset;
+    }
+
+    private static void EnsureBoardTrigger()
+    {
+        if (s_BoardTransform == null)
+        {
+            return;
+        }
+
+        const string triggerName = "BoardTrigger";
+        Transform triggerTransform = s_BoardTransform.Find(triggerName);
+        if (triggerTransform == null)
+        {
+            GameObject triggerObj = new GameObject(triggerName);
+            triggerObj.transform.SetParent(s_BoardTransform, false);
+            triggerTransform = triggerObj.transform;
+        }
+
+        triggerTransform.localPosition = new Vector3((s_GridSize - 1) * s_TileSize * 0.5f, (s_GridSize - 1) * s_TileSize * 0.5f, 0f);
+
+        BoxCollider2D collider = triggerTransform.GetComponent<BoxCollider2D>();
+        if (collider == null)
+        {
+            collider = triggerTransform.gameObject.AddComponent<BoxCollider2D>();
+        }
+
+        collider.isTrigger = true;
+        collider.size = new Vector2(s_GridSize * s_TileSize, s_GridSize * s_TileSize);
     }
 
     private static void RecalculateBoardCenter()

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -395,13 +395,8 @@ public class PuckController : MonoBehaviour
         yield return new WaitForFixedUpdate();
         yield return new WaitUntil(() => m_Rigidbody.velocity.magnitude <= STOP_THRESHOLD);
 
-        bool reachedBoard = transform.position.y >= m_BottomEntryY && transform.position.y <= m_TopEntryY;
-
-        if (reachedBoard)
+        if (m_HasReachedBoard)
         {
-
-            m_HasReachedBoard = true;
-
             s_ActivePuck = null;
             s_IsWhiteTurn = !s_IsWhiteTurn;
             if (Phase2Manager.IsPhase2Active)
@@ -422,6 +417,15 @@ public class PuckController : MonoBehaviour
             m_Rigidbody.velocity = Vector2.zero;
             m_Rigidbody.angularVelocity = 0f;
             transform.rotation = Quaternion.identity;
+            m_HasReachedBoard = false;
+        }
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.gameObject.name == "BoardTrigger")
+        {
+            m_HasReachedBoard = true;
         }
     }
 


### PR DESCRIPTION
## Summary
- Create invisible BoxCollider2D trigger sized to the board and attach it when setting the board
- Detect board trigger entry in PuckController and gate turn logic on m_HasReachedBoard

## Testing
- `dotnet build Puckslide/Assembly-CSharp.csproj` *(fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d59e2bc4832f9a176e244424d582