### PR TITLE
Map chess piece prefab to existing sprites

### DIFF
--- a/Puckslide/Assets/Prefabs/Piece.prefab
+++ b/Puckslide/Assets/Prefabs/Piece.prefab
@@ -76,7 +76,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 1
-  m_Sprite: {fileID: 1680065407, guid: 6acb7277238c618429fd6c515f84ce01, type: 3}
+  m_Sprite: {fileID: -2072918684, guid: 6acb7277238c618429fd6c515f84ce01, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -147,31 +147,3 @@ MonoBehaviour:
   - {fileID: 1680065407, guid: 6acb7277238c618429fd6c515f84ce01, type: 3}
   - {fileID: -1381916781, guid: 6acb7277238c618429fd6c515f84ce01, type: 3}
   - {fileID: -125045574, guid: 6acb7277238c618429fd6c515f84ce01, type: 3}
-  m_SpriteRenderer: {fileID: 3060614272095451322}
---- !u!50 &868649846776551746
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8750761313131887886}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -127,6 +127,8 @@ public class PuckController : MonoBehaviour
             return;
         }
 
+        float puckRadius = m_Collider != null ? m_Collider.bounds.extents.x : 0f;
+
         // Prefer the BoardTrigger collider to avoid including launch-area tiles
         // when calculating the board bounds.
         Transform trigger = board.Find("BoardTrigger");
@@ -137,8 +139,10 @@ public class PuckController : MonoBehaviour
             m_BottomEntryY = bounds.min.y;
             m_TopEntryY = bounds.max.y;
             m_HalfBoardY = (m_TopEntryY + m_BottomEntryY) * 0.5f;
-            m_LeftWallX = bounds.min.x + radius;
-            m_RightWallX = bounds.max.x - radius;
+
+            m_LeftWallX = bounds.min.x + puckRadius;
+            m_RightWallX = bounds.max.x - puckRadius;
+
             return;
         }
 
@@ -201,8 +205,10 @@ public class PuckController : MonoBehaviour
         m_BottomEntryY = minY - halfHeight;
         m_TopEntryY = maxY + halfHeight;
         m_HalfBoardY = (m_TopEntryY + m_BottomEntryY) * 0.5f;
-        m_LeftWallX = minX - halfWidth + radius;
-        m_RightWallX = maxX + halfWidth - radius;
+
+        m_LeftWallX = minX - halfWidth + puckRadius;
+        m_RightWallX = maxX + halfWidth - puckRadius;
+
     }
 
     private void OnEnable()

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -51,6 +51,8 @@ public class PuckController : MonoBehaviour
     private float m_BottomEntryY;
     private float m_TopEntryY;
     private float m_HalfBoardY;
+    private float m_LeftWallX;
+    private float m_RightWallX;
 
     private Vector3 m_StartPosition;
     private bool m_HasReachedBoard;
@@ -120,6 +122,8 @@ public class PuckController : MonoBehaviour
             m_BottomEntryY = 0f;
             m_TopEntryY = 0f;
             m_HalfBoardY = 0f;
+            m_LeftWallX = 0f;
+            m_RightWallX = 0f;
             return;
         }
 
@@ -129,9 +133,12 @@ public class PuckController : MonoBehaviour
         if (trigger != null && trigger.TryGetComponent(out BoxCollider2D box))
         {
             Bounds bounds = box.bounds;
+            float radius = m_Collider != null ? m_Collider.bounds.extents.x : 0f;
             m_BottomEntryY = bounds.min.y;
             m_TopEntryY = bounds.max.y;
             m_HalfBoardY = (m_TopEntryY + m_BottomEntryY) * 0.5f;
+            m_LeftWallX = bounds.min.x + radius;
+            m_RightWallX = bounds.max.x - radius;
             return;
         }
 
@@ -143,25 +150,34 @@ public class PuckController : MonoBehaviour
             m_BottomEntryY = 0f;
             m_TopEntryY = 0f;
             m_HalfBoardY = 0f;
+            m_LeftWallX = 0f;
+            m_RightWallX = 0f;
             return;
         }
 
         float minY = tiles[0].transform.position.y;
         float maxY = minY;
+        float minX = tiles[0].transform.position.x;
+        float maxX = minX;
         float halfHeight;
+        float halfWidth;
         SpriteRenderer sr = tiles[0].GetComponent<SpriteRenderer>();
         if (sr != null)
         {
             halfHeight = sr.bounds.extents.y;
+            halfWidth = sr.bounds.extents.x;
         }
         else
         {
-            halfHeight = tiles[0].transform.localScale.y * 0.5f;
+            Vector3 scale = tiles[0].transform.localScale;
+            halfHeight = scale.y * 0.5f;
+            halfWidth = scale.x * 0.5f;
         }
 
         for (int i = 1; i < tiles.Length; i++)
         {
-            float y = tiles[i].transform.position.y;
+            Vector3 pos = tiles[i].transform.position;
+            float y = pos.y;
             if (y < minY)
             {
                 minY = y;
@@ -170,11 +186,23 @@ public class PuckController : MonoBehaviour
             {
                 maxY = y;
             }
+            float x = pos.x;
+            if (x < minX)
+            {
+                minX = x;
+            }
+            if (x > maxX)
+            {
+                maxX = x;
+            }
         }
 
+        float radius = m_Collider != null ? m_Collider.bounds.extents.x : 0f;
         m_BottomEntryY = minY - halfHeight;
         m_TopEntryY = maxY + halfHeight;
         m_HalfBoardY = (m_TopEntryY + m_BottomEntryY) * 0.5f;
+        m_LeftWallX = minX - halfWidth + radius;
+        m_RightWallX = maxX + halfWidth - radius;
     }
 
     private void OnEnable()
@@ -419,6 +447,16 @@ public class PuckController : MonoBehaviour
         for (int i = 1; i <= steps; i++)
         {
             position += velocity * timeStep;
+            if (position.x < m_LeftWallX)
+            {
+                position.x = m_LeftWallX + (m_LeftWallX - position.x);
+                velocity.x = -velocity.x;
+            }
+            else if (position.x > m_RightWallX)
+            {
+                position.x = m_RightWallX - (position.x - m_RightWallX);
+                velocity.x = -velocity.x;
+            }
             m_TrajectoryRenderer.SetPosition(i, new Vector3(position.x, position.y, 0f));
             velocity *= friction;
         }


### PR DESCRIPTION
## Summary
- remove generated `ChessPiecesNew.png` sheet to avoid binary asset
- update `Piece` prefab sprite list to use existing `Chess Pieces.png` slices ordered by `ChessPiece` enum

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a5206afc832f9f58dd6896ab82af