### PR TITLE
Restore sticky pieces label on menu

### DIFF
--- a/Puckslide/Assets/Scenes/Main.unity
+++ b/Puckslide/Assets/Scenes/Main.unity
@@ -180,7 +180,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: White's turn
+  m_text: Sticky pieces
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}

--- a/Puckslide/Assets/Scripts/UI/TurnIndicator.cs
+++ b/Puckslide/Assets/Scripts/UI/TurnIndicator.cs
@@ -30,7 +30,7 @@ public class TurnIndicator : MonoBehaviour
 
     private void OnEnable()
     {
-        EventsManager.OnTurnChanged.AddListener(OnTurnChanged, true);
+        EventsManager.OnTurnChanged.AddListener(OnTurnChanged);
     }
 
     private void OnDisable()


### PR DESCRIPTION
## Summary
- Ensure the main menu displays "Sticky pieces" text above check boxes
- Delay turn text updates until turns actually change

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ecca25e0832f9ec9846aeed6a995