### PR TITLE
Centralize turn tracking through EventsManager

### DIFF
--- a/Puckslide/Assets/Scripts/Chess/BoardController.cs
+++ b/Puckslide/Assets/Scripts/Chess/BoardController.cs
@@ -27,7 +27,6 @@ public class BoardController : MonoBehaviour
     private Piece m_SelectedPiece;
     private Vector3 m_Offset;
     private Tile m_OriginalTile;
-    private bool? m_LastMoveWasWhite = null;
 
     private struct Move
     {
@@ -55,7 +54,6 @@ public class BoardController : MonoBehaviour
         }
         
         EventsManager.OnBoardLayout.AddListener(OnBoardLayout, true);
-        m_LastMoveWasWhite = null;
     }
     
     private void OnDisable()
@@ -145,7 +143,7 @@ public class BoardController : MonoBehaviour
             }
 
             // If we found a piece, check turn and "pick it up"
-            if (topmostPiece != null && (m_LastMoveWasWhite == null || topmostPiece.IsWhite() != m_LastMoveWasWhite.Value))
+            if (topmostPiece != null && topmostPiece.IsWhite() == EventsManager.IsWhiteTurn)
             {
                 m_SelectedPiece = topmostPiece;
                 m_OriginalTile = m_SelectedPiece.GetCurrentTile();
@@ -232,12 +230,11 @@ public class BoardController : MonoBehaviour
                         PromotionPanel.Instance.ShowPanel(m_SelectedPiece, tileBelow);
                     }
 
-                    m_LastMoveWasWhite = m_SelectedPiece.IsWhite();
-                    BoardFlipper.FlipCamera();
+                    EventsManager.ToggleTurn();
                     moveMade = true;
 
                     // Evaluate opponent's state
-                    EvaluateGameState(!m_LastMoveWasWhite.Value);
+                    EvaluateGameState(EventsManager.IsWhiteTurn);
                 }
             }
 

--- a/Puckslide/Assets/Scripts/GameSetupManager.cs
+++ b/Puckslide/Assets/Scripts/GameSetupManager.cs
@@ -48,7 +48,7 @@ public class GameSetupManager : MonoBehaviour
     private void OnEnable()
     {
         EventsManager.OnDeletePucks.Invoke(true);
-        PuckController.ResetTurnOrder();
+        EventsManager.ResetTurn();
 
         m_PieceSetup = new PieceSetupData[]
         {

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -43,7 +43,6 @@ public class PuckController : MonoBehaviour
 
     [SerializeField]
     private float m_MaxLineWidth = 0.3f;
-    private static bool s_IsWhiteTurn = true;
     private static PuckController s_ActivePuck;
     private bool m_IsSelected;
 
@@ -279,7 +278,7 @@ public class PuckController : MonoBehaviour
     private void OnMouseDown()
     {
 
-        if (IsWhitePiece != s_IsWhiteTurn || (s_ActivePuck != null && s_ActivePuck != this) || m_HasReachedBoard || m_Rigidbody.velocity.magnitude > STOP_THRESHOLD)
+        if (IsWhitePiece != EventsManager.IsWhiteTurn || (s_ActivePuck != null && s_ActivePuck != this) || m_HasReachedBoard || m_Rigidbody.velocity.magnitude > STOP_THRESHOLD)
 
         {
             m_IsSelected = false;
@@ -451,16 +450,7 @@ public class PuckController : MonoBehaviour
         if (m_HasReachedBoard)
         {
             s_ActivePuck = null;
-            s_IsWhiteTurn = !s_IsWhiteTurn;
-            if (Phase2Manager.IsPhase2Active)
-            {
-                BoardFlipper.FlipCamera();
-            }
-            else
-            {
-                BoardFlipper.Flip();
-            }
-            EventsManager.OnTurnChanged.Invoke(s_IsWhiteTurn);
+            EventsManager.ToggleTurn();
         }
         else
         {
@@ -486,14 +476,6 @@ public class PuckController : MonoBehaviour
     public ChessPiece ChessPiece { get; private set; }
 
     public bool IsWhitePiece => (int)ChessPiece >= 6;
-
-    public static bool IsWhiteTurn => s_IsWhiteTurn;
-
-    public static void ResetTurnOrder()
-    {
-        s_IsWhiteTurn = true; // Start with white's turn
-        EventsManager.OnTurnChanged.Invoke(s_IsWhiteTurn);
-    }
 
     public void UpdateGridPosition(float tileSize, Vector2 gridOrigin)
     {

--- a/Puckslide/Assets/Scripts/UI/Phase1PieceButton.cs
+++ b/Puckslide/Assets/Scripts/UI/Phase1PieceButton.cs
@@ -49,7 +49,7 @@ public class Phase1PieceButton : MonoBehaviour
             return;
         }
 
-        if (PuckController.IsWhiteTurn != m_IsWhite)
+        if (EventsManager.IsWhiteTurn != m_IsWhite)
         {
             return;
         }

--- a/Puckslide/Assets/Scripts/UI/TurnIndicator.cs
+++ b/Puckslide/Assets/Scripts/UI/TurnIndicator.cs
@@ -9,6 +9,8 @@ public class TurnIndicator : MonoBehaviour
     [SerializeField]
     private Vector3 m_Offset = new Vector3(0f, 0f, -0.1f);
 
+    private bool m_SkipFlip = true;
+
     private void Awake()
     {
         if (m_Text == null)
@@ -30,7 +32,7 @@ public class TurnIndicator : MonoBehaviour
 
     private void OnEnable()
     {
-        EventsManager.OnTurnChanged.AddListener(OnTurnChanged);
+        EventsManager.OnTurnChanged.AddListener(OnTurnChanged, true);
     }
 
     private void OnDisable()
@@ -43,6 +45,21 @@ public class TurnIndicator : MonoBehaviour
         if (m_Text != null)
         {
             m_Text.text = isWhiteTurn ? "White's turn" : "Black's turn";
+        }
+
+        if (m_SkipFlip)
+        {
+            m_SkipFlip = false;
+            return;
+        }
+
+        if (Phase2Manager.IsPhase2Active)
+        {
+            BoardFlipper.FlipCamera();
+        }
+        else
+        {
+            BoardFlipper.Flip();
         }
     }
 }

--- a/Puckslide/Assets/Scripts/Util/EventsManager.cs
+++ b/Puckslide/Assets/Scripts/Util/EventsManager.cs
@@ -12,6 +12,20 @@ public static class EventsManager
     public static readonly Evt<Rigidbody2D> OnPuckDespawned = new Evt<Rigidbody2D>();
     public static readonly Evt<bool> OnTurnChanged = new Evt<bool>(true);
     public static readonly Evt<string> OnGameState = new Evt<string>();
+
+    public static bool IsWhiteTurn { get; private set; } = true;
+
+    public static void ResetTurn()
+    {
+        IsWhiteTurn = true;
+        OnTurnChanged.Invoke(IsWhiteTurn);
+    }
+
+    public static void ToggleTurn()
+    {
+        IsWhiteTurn = !IsWhiteTurn;
+        OnTurnChanged.Invoke(IsWhiteTurn);
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- Move turn state into `EventsManager` with helper methods to reset or toggle turns
- Refactor `PuckController` and `BoardController` to read/write the shared turn value and trigger turn changes via `EventsManager`
- Use `TurnIndicator`'s turn-change handler to flip the board/camera and update UI

## Testing
- `dotnet build Puckslide/Puckslide.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fb1392fc832fa83f8bb13893fabc