### PR TITLE
Enable phase 2 board flipping

### DIFF
--- a/Puckslide/Assets/Scripts/Chess/BoardController.cs
+++ b/Puckslide/Assets/Scripts/Chess/BoardController.cs
@@ -41,25 +41,38 @@ public class BoardController : MonoBehaviour
 
     private void OnEnable()
     {
+        Phase2Manager phase2 = FindObjectOfType<Phase2Manager>(true);
+        if (phase2 != null)
+        {
+            phase2.gameObject.SetActive(true);
+            phase2.enabled = true;
+        }
+
         for (int i = m_CapturedPiecesWhiteTransform.childCount - 1; i >= 0; i--)
         {
             Transform child = m_CapturedPiecesWhiteTransform.GetChild(i);
             Destroy(child.gameObject);
         }
-        
+
         for (int i = m_CapturedPiecesBlackTransform.childCount - 1; i >= 0; i--)
         {
             Transform child = m_CapturedPiecesBlackTransform.GetChild(i);
             Destroy(child.gameObject);
         }
-        
+
         EventsManager.OnBoardLayout.AddListener(OnBoardLayout, true);
     }
-    
+
     private void OnDisable()
     {
         EventsManager.OnBoardLayout.RemoveListener(OnBoardLayout);
-        
+
+        Phase2Manager phase2 = FindObjectOfType<Phase2Manager>(true);
+        if (phase2 != null)
+        {
+            phase2.enabled = false;
+        }
+
         Piece[] gamePieces = FindObjectsOfType<Piece>();
         foreach (Piece piece in gamePieces)
         {


### PR DESCRIPTION
## Summary
- Ensure Phase2Manager is activated when the chess board is enabled
- Disable Phase2Manager when the board controller shuts down

## Testing
- `dotnet build Puckslide/Puckslide.sln` *(fails: reference assemblies for .NET Framework v4.7.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ff0e8e70832f9e31e2eae7693b6b