### PR TITLE
Implement tile highlighting and piece selection logic

### DIFF
--- a/Puckslide/Assets/Scripts/Chess/Tile.cs
+++ b/Puckslide/Assets/Scripts/Chess/Tile.cs
@@ -6,6 +6,11 @@ public class Tile : MonoBehaviour
 {
     [SerializeField]
     private int m_Row;
+
+    [SerializeField]
+    private SpriteRenderer m_SpriteRenderer;
+
+    private Color m_DefaultColor;
     
     private Piece m_CurrentPiece;
 
@@ -32,5 +37,29 @@ public class Tile : MonoBehaviour
     public int GetRow()
     {
         return m_Row;
+    }
+
+    private void Awake()
+    {
+        if (m_SpriteRenderer != null)
+        {
+            m_DefaultColor = m_SpriteRenderer.color;
+        }
+    }
+
+    public void Highlight(Color color)
+    {
+        if (m_SpriteRenderer != null)
+        {
+            m_SpriteRenderer.color = color;
+        }
+    }
+
+    public void ClearHighlight()
+    {
+        if (m_SpriteRenderer != null)
+        {
+            m_SpriteRenderer.color = m_DefaultColor;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add tile `SpriteRenderer` highlighting API
- Select pieces with click, highlight legal moves, and support drag or click movement
- Indicate kings in check by coloring their tiles red and notify turn changes

## Testing
- ⚠️ `dotnet build Puckslide.sln` *(missing .NET Framework reference assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_68a60dfc1e24832f8bceb928543dd719