### PR TITLE
fix: reapply move highlights after turn change

### DIFF
--- a/Puckslide/Assets/Scripts/Chess/BoardController.cs
+++ b/Puckslide/Assets/Scripts/Chess/BoardController.cs
@@ -84,6 +84,10 @@ public class BoardController : MonoBehaviour
     private void OnTurnChanged(bool _)
     {
         ClearHighlights();
+        if (m_SelectedPiece != null)
+        {
+            HighlightMoves(m_SelectedPiece);
+        }
     }
 
     private void OnBoardLayout(Dictionary<Vector2Int, ChessPiece> layout)


### PR DESCRIPTION
## Summary
- restore move highlights if the turn changes while a piece remains selected

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a61edc2d30832fa42e39455213ce4d