### PR TITLE
Refresh puck grid layout on select and stop

### DIFF
--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -56,6 +56,8 @@ public class PuckController : MonoBehaviour
     private Vector3 m_StartPosition;
     private bool m_HasReachedBoard;
 
+    private GridManager m_GridManager;
+
     // Cached board data used for highlighting legal moves.
     private static readonly List<Tile> s_HighlightedTiles = new List<Tile>();
     private static Dictionary<Vector2Int, Tile> s_TileMap;
@@ -73,6 +75,7 @@ public class PuckController : MonoBehaviour
         }
         m_PuckFriction = GetComponent<PuckFriction>();
         m_Collider = GetComponent<CircleCollider2D>();
+        m_GridManager = FindObjectOfType<GridManager>();
 
         if (m_Collider != null)
         {
@@ -327,7 +330,7 @@ public class PuckController : MonoBehaviour
             m_TrajectoryRenderer.startWidth = m_MinLineWidth;
             m_TrajectoryRenderer.endWidth = m_MinLineWidth;
         }
-
+        m_GridManager?.UpdatePieceLayout();
         HighlightLegalMoves();
     }
 
@@ -483,6 +486,8 @@ public class PuckController : MonoBehaviour
             transform.rotation = Quaternion.identity;
             m_HasReachedBoard = false;
         }
+
+        m_GridManager?.UpdatePieceLayout();
     }
 
     private void OnTriggerEnter2D(Collider2D other)


### PR DESCRIPTION
## Summary
- cache GridManager in PuckController
- refresh puck grid layout before highlighting legal moves
- update layout again when a puck stops moving

## Testing
- `dotnet build Puckslide.sln` *(fails: reference assemblies for .NETFramework,Version=v4.7.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a624f5bb48832f9abb7af6e83ab0dc