### PR TITLE
Use dotted line for predicted puck trajectory

### DIFF
--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -110,10 +110,10 @@ public class PuckController : MonoBehaviour
             var dottedMat = new Material(Shader.Find("Sprites/Default"));
             dottedMat.mainTexture = dotTex;
             m_TrajectoryRenderer.material = dottedMat;
-            // Reduce the texture scale so the two-pixel pattern tiles more
-            // frequently along the line, giving the appearance of many closely
-            // spaced dots.
-            m_TrajectoryRenderer.material.mainTextureScale = new Vector2(2f, 1f);
+            // Increase the texture tiling so the two-pixel pattern repeats
+            // more often, giving the appearance of many closely spaced dots
+            // instead of longer dashes.
+            m_TrajectoryRenderer.material.mainTextureScale = new Vector2(4f, 1f);
         }
 
 


### PR DESCRIPTION
## Summary
- increase texture tiling on trajectory renderer to render densely dotted path instead of dashes

## Testing
- `dotnet build Puckslide.sln` (fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)


------
https://chatgpt.com/codex/tasks/task_e_68a6277263b4832fa73769d4eccb4ae6