### PR TITLE
Change trajectory line color to blue

### DIFF
--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -86,8 +86,8 @@ public class PuckController : MonoBehaviour
         if (m_TrajectoryRenderer != null)
         {
             m_TrajectoryRenderer.enabled = false;
-            m_TrajectoryRenderer.startColor = Color.red;
-            m_TrajectoryRenderer.endColor = Color.red;
+            m_TrajectoryRenderer.startColor = Color.blue;
+            m_TrajectoryRenderer.endColor = Color.blue;
             m_TrajectoryRenderer.textureMode = LineTextureMode.Tile;
             m_TrajectoryRenderer.positionCount = 0;
             m_TrajectoryRenderer.startWidth = m_MinLineWidth;


### PR DESCRIPTION
## Summary
- set puck trajectory line renderer color to blue

## Testing
- `dotnet test Puckslide.sln` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a629acd980832f912c5ce669091736