### PR TITLE
Use red trajectory line in puck controller

### DIFF
--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -86,8 +86,8 @@ public class PuckController : MonoBehaviour
         if (m_TrajectoryRenderer != null)
         {
             m_TrajectoryRenderer.enabled = false;
-            m_TrajectoryRenderer.startColor = Color.blue;
-            m_TrajectoryRenderer.endColor = Color.blue;
+            m_TrajectoryRenderer.startColor = Color.red;
+            m_TrajectoryRenderer.endColor = Color.red;
             m_TrajectoryRenderer.textureMode = LineTextureMode.Tile;
             m_TrajectoryRenderer.positionCount = 0;
             m_TrajectoryRenderer.startWidth = m_MinLineWidth;


### PR DESCRIPTION
## Summary
- update puck trajectory line colors from blue to red

## Testing
- `dotnet build Puckslide.sln` *(fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a62c54f458832f82b208dca5e23424