### PR TITLE
Measure puck drag from puck center

### DIFF
--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -304,7 +304,7 @@ public class PuckController : MonoBehaviour
             m_Rigidbody.bodyType = RigidbodyType2D.Dynamic;
         }
 
-        m_DragStartPos = m_Camera.ScreenToWorldPoint(Input.mousePosition);
+        m_DragStartPos = transform.position;
         
         if (m_LineRenderer != null)
         {


### PR DESCRIPTION
## Summary
- Measure drag from the puck's center to ensure consistent launch vectors
- Keep launch force computation based on the center-derived drag vector

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a62d1d9ec4832f8e9425503879bd19