### PR TITLE
Avoid snapping puck on selection

### DIFF
--- a/Puckslide/Assets/Scripts/GridManager.cs
+++ b/Puckslide/Assets/Scripts/GridManager.cs
@@ -63,6 +63,32 @@ public class GridManager : MonoBehaviour
         EventsManager.OnBoardLayout.Invoke(m_PieceLayout);
     }
 
+    // Rebuild the board layout without altering puck positions.
+    public void UpdatePieceLayoutWithoutSnap()
+    {
+        m_PieceLayout.Clear();
+
+        // Find all pucks in the scene
+        PuckController[] pucks = FindObjectsOfType<PuckController>();
+
+        foreach (PuckController puck in pucks)
+        {
+            // Update each puck's grid position based on its current location
+            puck.UpdateGridPosition(m_TileSize, m_GridOrigin);
+
+            if (puck.CurrentGridPosition != new Vector2Int(-1, -1))
+            {
+                if (m_PieceLayout.ContainsKey(puck.CurrentGridPosition))
+                {
+                    Debug.LogWarning($"Duplicate piece at {puck.CurrentGridPosition} replaced.");
+                }
+                m_PieceLayout[puck.CurrentGridPosition] = puck.ChessPiece;
+            }
+        }
+
+        EventsManager.OnBoardLayout.Invoke(m_PieceLayout);
+    }
+
     void OnDrawGizmos()
     {
         // Draw the grid in the scene view for debugging

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -330,7 +330,9 @@ public class PuckController : MonoBehaviour
             m_TrajectoryRenderer.startWidth = m_MinLineWidth;
             m_TrajectoryRenderer.endWidth = m_MinLineWidth;
         }
-        m_GridManager?.UpdatePieceLayout();
+        // Update layout without snapping pieces to the grid so the selected
+        // puck doesn't move when highlighted.
+        m_GridManager?.UpdatePieceLayoutWithoutSnap();
         HighlightLegalMoves();
     }
 


### PR DESCRIPTION
## Summary
- Prevent puck from snapping to grid when selected by removing layout update with snap in `OnMouseDown`.
- Introduce `UpdatePieceLayoutWithoutSnap` in `GridManager` to rebuild board layout without moving pieces, ensuring legal move highlighting still works.

## Testing
- ⚠️ `dotnet build Puckslide.sln` *(missing: dotnet)*
- ⚠️ `apt-get install -y dotnet-sdk-7.0` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a632a0ab60832fae976f7d48fdbb4d