### PR TITLE
Avoid auto grid snapping on puck stop

### DIFF
--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -489,7 +489,10 @@ public class PuckController : MonoBehaviour
             m_HasReachedBoard = false;
         }
 
-        m_GridManager?.UpdatePieceLayout();
+        // Rebuild the board layout without altering puck positions so pucks
+        // remain exactly where they stopped. Snapping to grid now happens only
+        // when triggered explicitly (e.g. via the snap button).
+        m_GridManager?.UpdatePieceLayoutWithoutSnap();
     }
 
     private void OnTriggerEnter2D(Collider2D other)


### PR DESCRIPTION
## Summary
- stop automatic grid snapping after a puck stops moving
- keep layout rebuild without moving pucks, snapping now only happens via button

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a63472a6b4832f84c65e7df4efecb1