### PR TITLE
Snap pucks using scene-wide search

### DIFF
--- a/Puckslide/Assets/Scripts/GridManager.cs
+++ b/Puckslide/Assets/Scripts/GridManager.cs
@@ -24,7 +24,7 @@ public class GridManager : MonoBehaviour
 
     private IEnumerator SnapPucksOneByOne(float delay)
     {
-        PuckController[] pucks = GetComponentsInChildren<PuckController>();
+        PuckController[] pucks = FindObjectsOfType<PuckController>();
 
         foreach (PuckController puck in pucks)
         {


### PR DESCRIPTION
## Summary
- snap all pucks using `FindObjectsOfType` to ensure newly spawned objects are handled

## Testing
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*
- `dotnet build Puckslide.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab401c3608832fab65cc1847938369