### PR TITLE
Expose grid origin and use in Phase 2 puck collection

### DIFF
--- a/Puckslide/Assets/Scripts/GridManager.cs
+++ b/Puckslide/Assets/Scripts/GridManager.cs
@@ -7,6 +7,7 @@ public class GridManager : MonoBehaviour
 {
     [SerializeField] private float m_TileSize = 1f; // Match this to your tile size
     [SerializeField] private Vector2 m_GridOrigin = Vector2.zero; // Bottom-left of the grid
+    public Vector2 GridOrigin => m_GridOrigin;
     private GameState m_GameState => GameState.Instance;
 
     private void Update()

--- a/Puckslide/Assets/Scripts/Phase2Manager.cs
+++ b/Puckslide/Assets/Scripts/Phase2Manager.cs
@@ -48,10 +48,11 @@ public class Phase2Manager : MonoBehaviour
     {
         GameState state = GameState.Instance;
         state.Clear();
+        GridManager gridManager = FindObjectOfType<GridManager>();
         foreach (PuckController puck in FindObjectsOfType<PuckController>())
         {
             // Update each puck's grid position and record it if valid.
-            puck.UpdateGridPosition(m_TileSize, Vector2.zero);
+            puck.UpdateGridPosition(m_TileSize, gridManager.GridOrigin);
             Vector2Int pos = puck.CurrentGridPosition;
             if (pos.x >= 0 && pos.y >= 0)
             {


### PR DESCRIPTION
## Summary
- Expose `GridOrigin` from `GridManager` so other systems can align with the board.
- Use `GridManager.GridOrigin` when collecting puck positions for Phase 2.

## Testing
- `dotnet build Assembly-CSharp.csproj` *(fails: missing UnityEngine references)*

------
https://chatgpt.com/codex/tasks/task_e_68ab434d87bc832fa1d7105bc32bd94b