### PR TITLE
Clear old pucks before building Phase 2 board

### DIFF
--- a/Puckslide/Assets/Scripts/Phase2Manager.cs
+++ b/Puckslide/Assets/Scripts/Phase2Manager.cs
@@ -20,16 +20,18 @@ public class Phase2Manager : MonoBehaviour
     private void OnEnable()
     {
         IsPhase2Active = true;
-        // Collect the current puck layout and record it in the GameState
-        // before removing the physical pucks from the board.
+        // Record the current puck layout before we remove the physical pucks
+        // from the board.
         CollectPucks();
+
+        // Destroy any existing pucks so only Phase 2 pieces remain when the
+        // expanded board becomes active.
+        EventsManager.OnDeletePucks.Invoke(true);
+
+        // Rebuild the board with Phase 2 chess pieces based on the recorded
+        // layout.
         GridManager gridManager = FindObjectOfType<GridManager>();
         gridManager?.UpdatePieceLayout();
-
-        // Clear any lingering pucks from the board. Pieces will be spawned
-        // from the last recorded layout by the BoardController, so avoid
-        // destroying them here.
-        EventsManager.OnDeletePucks.Invoke(true);
 
         // Ensure the BoardFlipper knows about the Phase 2 board so pieces
         // remain aligned when the board is rotated.


### PR DESCRIPTION
## Summary
- destroy PuckController instances before enabling the Phase 2 board
- rebuild the Phase 2 board with chess pieces from the recorded layout

## Testing
- `dotnet build Puckslide.sln` *(fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab46fa26fc832fbd31ca2d453bf7e7