### PR TITLE
feat: central turn manager for network play

### DIFF
--- a/Puckslide/Assembly-CSharp.csproj
+++ b/Puckslide/Assembly-CSharp.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <Compile Include="Assets\Scripts\Phase2Manager.cs" />
     <Compile Include="Assets\Scripts\PuckController.cs" />
+    <Compile Include="Assets\Scripts\Core\TurnManager.cs" />
     <Compile Include="Assets\Scripts\Chess\CapturedPieceUi.cs" />
     <Compile Include="Assets\Scripts\PuckFriction.cs" />
     <Compile Include="Assets\Scripts\Chess\Tile.cs" />

--- a/Puckslide/Assets/Scripts/Core/TurnManager.cs
+++ b/Puckslide/Assets/Scripts/Core/TurnManager.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
+using System.Text;
+using UnityEngine;
+
+[DataContract]
+public class TurnManager
+{
+    public static TurnManager Instance { get; set; } = new TurnManager();
+
+    [DataMember]
+    private PlayerColor m_CurrentPlayer = PlayerColor.White;
+
+    [IgnoreDataMember]
+    private PuckController m_ActivePuck;
+
+    [IgnoreDataMember]
+    private IEventBus m_EventBus;
+
+    private IEventBus Bus => m_EventBus ??= Object.FindObjectOfType<EventBusBootstrap>()?.Bus;
+
+    public PlayerColor CurrentPlayer => m_CurrentPlayer;
+    public bool IsWhiteTurn => m_CurrentPlayer == PlayerColor.White;
+    public PuckController ActivePuck
+    {
+        get => m_ActivePuck;
+        set => m_ActivePuck = value;
+    }
+
+    public void BeginTurn(PlayerColor c)
+    {
+        m_CurrentPlayer = c;
+        m_ActivePuck = null;
+        Bus?.Publish(EventBusEvents.TurnChanged, IsWhiteTurn);
+    }
+
+    public void EndTurn()
+    {
+        m_CurrentPlayer = m_CurrentPlayer == PlayerColor.White ? PlayerColor.Black : PlayerColor.White;
+        m_ActivePuck = null;
+        Bus?.Publish(EventBusEvents.TurnChanged, IsWhiteTurn);
+    }
+
+    public string ToJson()
+    {
+        var serializer = new DataContractJsonSerializer(typeof(TurnManager));
+        using (var ms = new MemoryStream())
+        {
+            serializer.WriteObject(ms, this);
+            return Encoding.UTF8.GetString(ms.ToArray());
+        }
+    }
+
+    public static TurnManager FromJson(string json)
+    {
+        var serializer = new DataContractJsonSerializer(typeof(TurnManager));
+        using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+        {
+            return (TurnManager)serializer.ReadObject(ms);
+        }
+    }
+}
+
+public enum PlayerColor
+{
+    White,
+    Black
+}

--- a/Puckslide/Assets/Scripts/Core/TurnManager.cs.meta
+++ b/Puckslide/Assets/Scripts/Core/TurnManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 91d9901ce8e64e87a4484a7e14e574a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Puckslide/Assets/Scripts/GameSetupManager.cs
+++ b/Puckslide/Assets/Scripts/GameSetupManager.cs
@@ -53,7 +53,7 @@ public class GameSetupManager : MonoBehaviour
     private void OnEnable()
     {
         m_EventBus?.Publish(EventBusEvents.DeletePucks, true);
-        PuckController.ResetTurnOrder();
+        TurnManager.Instance.BeginTurn(PlayerColor.White);
 
         m_PieceSetup = new PieceSetupData[]
         {

--- a/Puckslide/Assets/Scripts/UI/Phase1PieceButton.cs
+++ b/Puckslide/Assets/Scripts/UI/Phase1PieceButton.cs
@@ -55,7 +55,7 @@ public class Phase1PieceButton : MonoBehaviour
             return;
         }
 
-        if (PuckController.IsWhiteTurn != m_IsWhite)
+        if (TurnManager.Instance.IsWhiteTurn != m_IsWhite)
         {
             return;
         }


### PR DESCRIPTION
## Summary
- add TurnManager to track turns and active puck and broadcast changes
- query TurnManager from PuckController and Phase1 UI instead of static fields
- initialize turns via TurnManager for setup

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6aa4403c832f936ce97f4fc54795