### PR TITLE
Introduce network sync messages for board layout and moves

### DIFF
--- a/Puckslide/Assets/Scripts/Chess/BoardController.cs
+++ b/Puckslide/Assets/Scripts/Chess/BoardController.cs
@@ -74,6 +74,7 @@ public class BoardController : MonoBehaviour
         }
 
         m_EventBus?.Subscribe<bool>(EventBusEvents.TurnChanged, OnTurnChanged, true);
+        m_EventBus?.Subscribe<BoardLayoutMessage>(EventBusEvents.BoardLayout, OnBoardLayout, true);
         m_LastMoveWasWhite = null;
         BuildFromState();
     }
@@ -81,6 +82,7 @@ public class BoardController : MonoBehaviour
     private void OnDisable()
     {
         m_EventBus?.Unsubscribe<bool>(EventBusEvents.TurnChanged, OnTurnChanged);
+        m_EventBus?.Unsubscribe<BoardLayoutMessage>(EventBusEvents.BoardLayout, OnBoardLayout);
 
         foreach (Piece piece in m_SpawnedPieces)
         {
@@ -99,6 +101,32 @@ public class BoardController : MonoBehaviour
         {
             HighlightMoves(m_SelectedPiece);
         }
+    }
+
+    private void OnBoardLayout(BoardLayoutMessage message)
+    {
+        GameState.Instance.ApplyBoardLayoutMessage(message);
+
+        foreach (Piece piece in m_SpawnedPieces)
+        {
+            if (piece != null)
+            {
+                Destroy(piece.gameObject);
+            }
+        }
+        m_SpawnedPieces.Clear();
+
+        for (int i = m_CapturedPiecesWhiteTransform.childCount - 1; i >= 0; i--)
+        {
+            Destroy(m_CapturedPiecesWhiteTransform.GetChild(i).gameObject);
+        }
+
+        for (int i = m_CapturedPiecesBlackTransform.childCount - 1; i >= 0; i--)
+        {
+            Destroy(m_CapturedPiecesBlackTransform.GetChild(i).gameObject);
+        }
+
+        BuildFromState();
     }
 
     private void BuildFromState()

--- a/Puckslide/Assets/Scripts/Core/GameState.cs
+++ b/Puckslide/Assets/Scripts/Core/GameState.cs
@@ -147,4 +147,39 @@ public class GameState
 #pragma warning restore SYSLIB0011
         }
     }
+
+    public BoardLayoutMessage ToBoardLayoutMessage()
+    {
+        return new BoardLayoutMessage
+        {
+            Board = GetLayout(),
+            CapturedWhite = new List<ChessPiece>(m_CapturedWhite),
+            CapturedBlack = new List<ChessPiece>(m_CapturedBlack),
+            WhiteTurn = m_WhiteTurn
+        };
+    }
+
+    public void ApplyBoardLayoutMessage(BoardLayoutMessage message)
+    {
+        m_Board = message.Board != null
+            ? new Dictionary<Position, ChessPiece>(message.Board)
+            : new Dictionary<Position, ChessPiece>();
+        m_CapturedWhite = message.CapturedWhite != null
+            ? new List<ChessPiece>(message.CapturedWhite)
+            : new List<ChessPiece>();
+        m_CapturedBlack = message.CapturedBlack != null
+            ? new List<ChessPiece>(message.CapturedBlack)
+            : new List<ChessPiece>();
+        m_WhiteTurn = message.WhiteTurn;
+    }
+
+    public static MoveMessage ToMoveMessage(Move move)
+    {
+        return new MoveMessage { From = move.From, To = move.To };
+    }
+
+    public static Move FromMoveMessage(MoveMessage message)
+    {
+        return new Move(message.From, message.To);
+    }
 }

--- a/Puckslide/Assets/Scripts/Core/NetworkMessages.cs
+++ b/Puckslide/Assets/Scripts/Core/NetworkMessages.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Runtime.Serialization.Json;
+using System.Text;
+
+[DataContract]
+public class BoardLayoutMessage
+{
+    [DataMember]
+    public Dictionary<Position, ChessPiece> Board { get; set; }
+
+    [DataMember]
+    public List<ChessPiece> CapturedWhite { get; set; }
+
+    [DataMember]
+    public List<ChessPiece> CapturedBlack { get; set; }
+
+    [DataMember]
+    public bool WhiteTurn { get; set; }
+}
+
+[DataContract]
+public struct MoveMessage
+{
+    [DataMember]
+    public Position From { get; set; }
+
+    [DataMember]
+    public Position To { get; set; }
+}
+
+public static class MessageSerializer
+{
+    public static string ToJson<T>(T obj)
+    {
+        var serializer = new DataContractJsonSerializer(typeof(T));
+        using (var ms = new MemoryStream())
+        {
+            serializer.WriteObject(ms, obj);
+            return Encoding.UTF8.GetString(ms.ToArray());
+        }
+    }
+
+    public static T FromJson<T>(string json)
+    {
+        var serializer = new DataContractJsonSerializer(typeof(T));
+        using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+        {
+            return (T)serializer.ReadObject(ms);
+        }
+    }
+
+    public static byte[] ToBinary<T>(T obj)
+    {
+        using (var ms = new MemoryStream())
+        {
+            var bf = new BinaryFormatter();
+#pragma warning disable SYSLIB0011
+            bf.Serialize(ms, obj);
+#pragma warning restore SYSLIB0011
+            return ms.ToArray();
+        }
+    }
+
+    public static T FromBinary<T>(byte[] data)
+    {
+        using (var ms = new MemoryStream(data))
+        {
+            var bf = new BinaryFormatter();
+#pragma warning disable SYSLIB0011
+            return (T)bf.Deserialize(ms);
+#pragma warning restore SYSLIB0011
+        }
+    }
+}

--- a/Puckslide/Assets/Scripts/GridManager.cs
+++ b/Puckslide/Assets/Scripts/GridManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class GridManager : MonoBehaviour
@@ -42,23 +41,13 @@ public class GridManager : MonoBehaviour
 
     public void UpdatePieceLayout()
     {
-        m_EventBus?.Publish(EventBusEvents.BoardLayout, ConvertLayout(m_GameState.GetLayout()));
+        m_EventBus?.Publish(EventBusEvents.BoardLayout, m_GameState.ToBoardLayoutMessage());
     }
 
     // Rebuild the board layout without altering puck positions.
     public void UpdatePieceLayoutWithoutSnap()
     {
-        m_EventBus?.Publish(EventBusEvents.BoardLayout, ConvertLayout(m_GameState.GetLayout()));
-    }
-
-    private Dictionary<Vector2Int, ChessPiece> ConvertLayout(Dictionary<Position, ChessPiece> layout)
-    {
-        var dict = new Dictionary<Vector2Int, ChessPiece>();
-        foreach (var kvp in layout)
-        {
-            dict[new Vector2Int(kvp.Key.X, kvp.Key.Y)] = kvp.Value;
-        }
-        return dict;
+        m_EventBus?.Publish(EventBusEvents.BoardLayout, m_GameState.ToBoardLayoutMessage());
     }
 
     void OnDrawGizmos()


### PR DESCRIPTION
## Summary
- define BoardLayoutMessage and MoveMessage for lightweight state sync
- add serializers and conversions between GameState and messages
- update board and grid controllers to use BoardLayoutMessage via event bus

## Testing
- ⚠️ `dotnet build Puckslide.sln` *(missing .NET Framework 4.7.1 reference assemblies)*


------
https://chatgpt.com/codex/tasks/task_e_68ab6c574108832fbc6c1f9677798558