### PR TITLE
Add puck and piece registries for event-driven lookups

### DIFF
--- a/Puckslide/Assets/Scripts/Chess/BoardController.cs
+++ b/Puckslide/Assets/Scripts/Chess/BoardController.cs
@@ -33,7 +33,6 @@ public class BoardController : MonoBehaviour
     private bool? m_LastMoveWasWhite = null;
 
     private readonly List<Tile> m_HighlightedTiles = new List<Tile>();
-    private readonly List<Piece> m_SpawnedPieces = new List<Piece>();
     private bool m_IsDragging = false;
     private bool m_MouseDownOnPiece = false;
     private Vector3 m_MouseDownPos;
@@ -83,15 +82,17 @@ public class BoardController : MonoBehaviour
     {
         m_EventBus?.Unsubscribe<bool>(EventBusEvents.TurnChanged, OnTurnChanged);
         m_EventBus?.Unsubscribe<BoardLayoutMessage>(EventBusEvents.BoardLayout, OnBoardLayout);
-
-        foreach (Piece piece in m_SpawnedPieces)
+        var registry = PieceRegistry.Instance;
+        if (registry != null)
         {
-            if (piece != null)
+            foreach (Piece piece in registry.GetPieces())
             {
-                Destroy(piece.gameObject);
+                if (piece != null)
+                {
+                    Destroy(piece.gameObject);
+                }
             }
         }
-        m_SpawnedPieces.Clear();
     }
 
     private void OnTurnChanged(bool _)
@@ -106,15 +107,17 @@ public class BoardController : MonoBehaviour
     private void OnBoardLayout(BoardLayoutMessage message)
     {
         GameState.Instance.ApplyBoardLayoutMessage(message);
-
-        foreach (Piece piece in m_SpawnedPieces)
+        var registry = PieceRegistry.Instance;
+        if (registry != null)
         {
-            if (piece != null)
+            foreach (Piece piece in registry.GetPieces())
             {
-                Destroy(piece.gameObject);
+                if (piece != null)
+                {
+                    Destroy(piece.gameObject);
+                }
             }
         }
-        m_SpawnedPieces.Clear();
 
         for (int i = m_CapturedPiecesWhiteTransform.childCount - 1; i >= 0; i--)
         {
@@ -156,7 +159,6 @@ public class BoardController : MonoBehaviour
                     tile.SetPiece(pieceScript);
                     pieceScript.SetTile(tile);
                     pieceScript.transform.SetParent(tile.transform);
-                    m_SpawnedPieces.Add(pieceScript);
                 }
                 else
                 {
@@ -444,7 +446,6 @@ public class BoardController : MonoBehaviour
                         isWhitePiece ? m_CapturedPiecesWhiteTransform : m_CapturedPiecesBlackTransform)
                     .GetComponent<CapturedPieceUi>();
             capUi.SetupCapturedUiPiece(capturedPiece.GetChessPiece());
-            m_SpawnedPieces.Remove(capturedPiece);
             Destroy(capturedPiece.gameObject);
         }
 

--- a/Puckslide/Assets/Scripts/Chess/Piece.cs
+++ b/Puckslide/Assets/Scripts/Chess/Piece.cs
@@ -17,6 +17,7 @@ public class Piece : MonoBehaviour
 
     private Tile m_CurrentTile;
     private ChessPiece m_ChessPiece;
+    private IEventBus m_EventBus;
     
     public Tile GetCurrentTile() => m_CurrentTile;
     public void SetTile(Tile tile) => m_CurrentTile = tile;
@@ -46,5 +47,20 @@ public class Piece : MonoBehaviour
     public bool IsPawn()
     {
         return m_ChessPiece is ChessPiece.B_Pawn or ChessPiece.W_Pawn;
+    }
+
+    private void Awake()
+    {
+        m_EventBus = FindObjectOfType<EventBusBootstrap>()?.Bus;
+    }
+
+    private void OnEnable()
+    {
+        m_EventBus?.Publish(EventBusEvents.PieceSpawned, this);
+    }
+
+    private void OnDisable()
+    {
+        m_EventBus?.Publish(EventBusEvents.PieceDespawned, this);
     }
 }

--- a/Puckslide/Assets/Scripts/GridManager.cs
+++ b/Puckslide/Assets/Scripts/GridManager.cs
@@ -30,7 +30,8 @@ public class GridManager : MonoBehaviour
 
     private IEnumerator SnapPucksOneByOne(float delay)
     {
-        PuckController[] pucks = FindObjectsOfType<PuckController>();
+        PuckRegistry registry = PuckRegistry.Instance;
+        PuckController[] pucks = registry != null ? registry.GetPucks() : Array.Empty<PuckController>();
 
         foreach (PuckController puck in pucks)
         {

--- a/Puckslide/Assets/Scripts/Registry/PieceRegistry.cs
+++ b/Puckslide/Assets/Scripts/Registry/PieceRegistry.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PieceRegistry : MonoBehaviour
+{
+    public static PieceRegistry Instance { get; private set; }
+
+    private readonly List<Piece> m_Pieces = new List<Piece>();
+    private IEventBus m_EventBus;
+
+    public Piece[] GetPieces()
+    {
+        return m_Pieces.ToArray();
+    }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        m_EventBus = FindObjectOfType<EventBusBootstrap>()?.Bus;
+    }
+
+    private void OnEnable()
+    {
+        m_EventBus?.Subscribe<Piece>(EventBusEvents.PieceSpawned, OnPieceSpawned);
+        m_EventBus?.Subscribe<Piece>(EventBusEvents.PieceDespawned, OnPieceDespawned);
+    }
+
+    private void OnDisable()
+    {
+        m_EventBus?.Unsubscribe<Piece>(EventBusEvents.PieceSpawned, OnPieceSpawned);
+        m_EventBus?.Unsubscribe<Piece>(EventBusEvents.PieceDespawned, OnPieceDespawned);
+        m_Pieces.Clear();
+    }
+
+    private void OnPieceSpawned(Piece piece)
+    {
+        if (piece != null && !m_Pieces.Contains(piece))
+        {
+            m_Pieces.Add(piece);
+        }
+    }
+
+    private void OnPieceDespawned(Piece piece)
+    {
+        m_Pieces.Remove(piece);
+    }
+}

--- a/Puckslide/Assets/Scripts/Registry/PuckRegistry.cs
+++ b/Puckslide/Assets/Scripts/Registry/PuckRegistry.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PuckRegistry : MonoBehaviour
+{
+    public static PuckRegistry Instance { get; private set; }
+
+    private readonly List<PuckController> m_Pucks = new List<PuckController>();
+    private IEventBus m_EventBus;
+
+    public PuckController[] GetPucks()
+    {
+        return m_Pucks.ToArray();
+    }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        m_EventBus = FindObjectOfType<EventBusBootstrap>()?.Bus;
+    }
+
+    private void OnEnable()
+    {
+        m_EventBus?.Subscribe<Rigidbody2D>(EventBusEvents.PuckSpawned, OnPuckSpawned);
+        m_EventBus?.Subscribe<Rigidbody2D>(EventBusEvents.PuckDespawned, OnPuckDespawned);
+    }
+
+    private void OnDisable()
+    {
+        m_EventBus?.Unsubscribe<Rigidbody2D>(EventBusEvents.PuckSpawned, OnPuckSpawned);
+        m_EventBus?.Unsubscribe<Rigidbody2D>(EventBusEvents.PuckDespawned, OnPuckDespawned);
+        m_Pucks.Clear();
+    }
+
+    private void OnPuckSpawned(Rigidbody2D rb)
+    {
+        var puck = rb != null ? rb.GetComponent<PuckController>() : null;
+        if (puck != null && !m_Pucks.Contains(puck))
+        {
+            m_Pucks.Add(puck);
+        }
+    }
+
+    private void OnPuckDespawned(Rigidbody2D rb)
+    {
+        var puck = rb != null ? rb.GetComponent<PuckController>() : null;
+        if (puck != null)
+        {
+            m_Pucks.Remove(puck);
+        }
+    }
+}

--- a/Puckslide/Assets/Scripts/Util/EventBusEvents.cs
+++ b/Puckslide/Assets/Scripts/Util/EventBusEvents.cs
@@ -5,6 +5,8 @@ public static class EventBusEvents
     public const string BoardLayout = "BoardLayout";
     public const string PuckSpawned = "PuckSpawned";
     public const string PuckDespawned = "PuckDespawned";
+    public const string PieceSpawned = "PieceSpawned";
+    public const string PieceDespawned = "PieceDespawned";
     public const string TurnChanged = "TurnChanged";
     public const string GameState = "GameState";
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Puck Slide
+
+## Registry Lifecycle
+
+The project now uses two registries to track active gameplay objects:
+
+- **PuckRegistry** maintains references to all `PuckController` instances.
+- **PieceRegistry** maintains references to all chess `Piece` instances.
+
+Each `PuckController` and `Piece` publishes spawn and despawn events through the global `EventBus` in their `OnEnable` and `OnDisable` methods. The registries subscribe to these `PuckSpawned`/`PuckDespawned` and `PieceSpawned`/`PieceDespawned` events and update their internal lists accordingly.
+
+Systems that previously searched the scene with `FindObjectsOfType` now query the registries instead. This event-driven approach avoids expensive scene scans and ensures all peers operating over the network share a consistent view of active objects. Consumers can obtain stable snapshots using `PuckRegistry.Instance.GetPucks()` and `PieceRegistry.Instance.GetPieces()`.
+
+When objects are destroyed or a scene is unloaded, their `OnDisable` method triggers the corresponding despawn event so the registries automatically stay in sync.
+
+Use these registries as the authoritative source of object lists for future network synchronization work.


### PR DESCRIPTION
## Summary
- add PuckRegistry and PieceRegistry to track objects via spawn/despawn events
- replace scene scans with registry queries in BoardController and GridManager
- document registry lifecycle for future network sync

## Testing
- `dotnet build Puckslide.sln` *(fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6de2d2a8832f991e949e3cfdfeb4