### PR TITLE
Use serializable list for board layout

### DIFF
--- a/Puckslide/Assets/Scripts/Core/GameState.cs
+++ b/Puckslide/Assets/Scripts/Core/GameState.cs
@@ -150,9 +150,15 @@ public class GameState
 
     public BoardLayoutMessage ToBoardLayoutMessage()
     {
+        var entries = new List<BoardEntry>();
+        foreach (var kvp in m_Board)
+        {
+            entries.Add(new BoardEntry { Pos = kvp.Key, Piece = kvp.Value });
+        }
+
         return new BoardLayoutMessage
         {
-            Board = GetLayout(),
+            Board = entries,
             CapturedWhite = new List<ChessPiece>(m_CapturedWhite),
             CapturedBlack = new List<ChessPiece>(m_CapturedBlack),
             WhiteTurn = m_WhiteTurn
@@ -161,9 +167,14 @@ public class GameState
 
     public void ApplyBoardLayoutMessage(BoardLayoutMessage message)
     {
-        m_Board = message.Board != null
-            ? new Dictionary<Position, ChessPiece>(message.Board)
-            : new Dictionary<Position, ChessPiece>();
+        m_Board = new Dictionary<Position, ChessPiece>();
+        if (message.Board != null)
+        {
+            foreach (var entry in message.Board)
+            {
+                m_Board[entry.Pos] = entry.Piece;
+            }
+        }
         m_CapturedWhite = message.CapturedWhite != null
             ? new List<ChessPiece>(message.CapturedWhite)
             : new List<ChessPiece>();

--- a/Puckslide/Assets/Scripts/Core/NetworkMessages.cs
+++ b/Puckslide/Assets/Scripts/Core/NetworkMessages.cs
@@ -7,10 +7,17 @@ using System.Runtime.Serialization.Json;
 using System.Text;
 
 [DataContract]
+public struct BoardEntry
+{
+    [DataMember] public Position Pos;
+    [DataMember] public ChessPiece Piece;
+}
+
+[DataContract]
 public class BoardLayoutMessage
 {
     [DataMember]
-    public Dictionary<Position, ChessPiece> Board { get; set; }
+    public List<BoardEntry> Board { get; set; }
 
     [DataMember]
     public List<ChessPiece> CapturedWhite { get; set; }


### PR DESCRIPTION
## Summary
- Represent board layout messages with a list of serializable `BoardEntry` items instead of dictionaries
- Convert game state to and from `BoardEntry` lists when sending or applying board layouts

## Testing
- `dotnet build Puckslide.sln` *(fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7116993c832faae44b13a7c4bf2e