### PR TITLE
Add Steam achievement hooks and release checklist

### DIFF
--- a/Puckslide/Assets/Scripts/Platform.meta
+++ b/Puckslide/Assets/Scripts/Platform.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63407de533b54fb9baf720a891b4cffe
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Puckslide/Assets/Scripts/Platform/SteamPlatformService.cs
+++ b/Puckslide/Assets/Scripts/Platform/SteamPlatformService.cs
@@ -1,0 +1,146 @@
+using System;
+
+#if STEAMWORKSNET
+using Steamworks;
+#endif
+
+/// <summary>
+/// Centralizes Steam-only hooks for achievements, overlay, and simple stat tracking.
+/// Calls are guarded by STEAMWORKSNET and runtime checks so non-Steam builds remain unaffected.
+/// </summary>
+public static class SteamPlatformService
+{
+#if STEAMWORKSNET
+    private const string AchievementHostedLobby = "ACH_SESSION_HOST";
+    private const string AchievementJoinedLobby = "ACH_SESSION_JOIN";
+    private const string AchievementReadyUp = "ACH_READY_UP";
+
+    private const string StatSessionsHosted = "STAT_SESSIONS_HOSTED";
+    private const string StatSessionsJoined = "STAT_SESSIONS_JOINED";
+    private const string StatReadyUps = "STAT_READY_UPS";
+
+    private static bool s_StatsRequested;
+
+    public static void EnsureInitialized()
+    {
+        if (s_StatsRequested || !SteamTransport.IsPlatformSupported)
+        {
+            return;
+        }
+
+        s_StatsRequested = SteamUserStats.RequestCurrentStats();
+    }
+
+    public static void ReportSessionHosted()
+    {
+        if (!EnsureStatsReady())
+        {
+            return;
+        }
+
+        UnlockAchievement(AchievementHostedLobby);
+        IncrementStat(StatSessionsHosted);
+    }
+
+    public static void ReportSessionJoined()
+    {
+        if (!EnsureStatsReady())
+        {
+            return;
+        }
+
+        UnlockAchievement(AchievementJoinedLobby);
+        IncrementStat(StatSessionsJoined);
+    }
+
+    public static void ReportReadyState()
+    {
+        if (!EnsureStatsReady())
+        {
+            return;
+        }
+
+        UnlockAchievement(AchievementReadyUp);
+        IncrementStat(StatReadyUps);
+    }
+
+    public static void OpenInviteOverlay(CSteamID lobbyId)
+    {
+        if (!SteamTransport.IsPlatformSupported)
+        {
+            return;
+        }
+
+        if (lobbyId == CSteamID.Nil)
+        {
+            SteamFriends.ActivateGameOverlay("Friends");
+            return;
+        }
+
+        SteamFriends.ActivateGameOverlayInviteDialog(lobbyId);
+    }
+
+    public static void OpenAchievementsOverlay()
+    {
+        if (!SteamTransport.IsPlatformSupported)
+        {
+            return;
+        }
+
+        SteamFriends.ActivateGameOverlay("Achievements");
+    }
+
+    private static bool EnsureStatsReady()
+    {
+        EnsureInitialized();
+
+        if (!SteamTransport.IsPlatformSupported || !s_StatsRequested)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void UnlockAchievement(string achievementId)
+    {
+        if (SteamUserStats.SetAchievement(achievementId))
+        {
+            SteamUserStats.StoreStats();
+        }
+    }
+
+    private static void IncrementStat(string statName)
+    {
+        if (SteamUserStats.GetStat(statName, out int current))
+        {
+            SteamUserStats.SetStat(statName, current + 1);
+            SteamUserStats.StoreStats();
+        }
+    }
+#else
+    public static void EnsureInitialized()
+    {
+    }
+
+    public static void ReportSessionHosted()
+    {
+    }
+
+    public static void ReportSessionJoined()
+    {
+    }
+
+    public static void ReportReadyState()
+    {
+    }
+
+    public static void OpenInviteOverlay(object lobbyId)
+    {
+    }
+
+    public static void OpenAchievementsOverlay()
+    {
+    }
+#endif
+}

--- a/Puckslide/Assets/Scripts/Platform/SteamPlatformService.cs.meta
+++ b/Puckslide/Assets/Scripts/Platform/SteamPlatformService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd53c4f8441b4ff69711aaf251e39cc8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Puckslide/Assets/Scripts/UI/LobbyUIController.cs
+++ b/Puckslide/Assets/Scripts/UI/LobbyUIController.cs
@@ -86,6 +86,12 @@ public class LobbyUIController : MonoBehaviour
         m_TimeProvider = new ManualTimeProvider();
         m_Transport = SteamTransport.IsPlatformSupported ? (NetTransport)new SteamTransport() : new LoopbackTransport();
         m_UsingSteam = m_Transport is SteamTransport;
+#if STEAMWORKSNET
+        if (m_UsingSteam)
+        {
+            SteamPlatformService.EnsureInitialized();
+        }
+#endif
         m_Lobby = new LobbyStateMachine(m_Transport);
         m_SessionManager = new ResilientSessionManager<string>(
             m_Lobby.Transport,
@@ -189,6 +195,12 @@ public class LobbyUIController : MonoBehaviour
         BeginResilientTracking();
         RegisterPrivacyTerms();
         UpdateStatus();
+#if STEAMWORKSNET
+        if (m_UsingSteam)
+        {
+            SteamPlatformService.ReportSessionHosted();
+        }
+#endif
     }
 
     public void OnJoinClicked()
@@ -198,6 +210,12 @@ public class LobbyUIController : MonoBehaviour
         BeginResilientTracking();
         RegisterPrivacyTerms();
         UpdateStatus();
+#if STEAMWORKSNET
+        if (m_UsingSteam)
+        {
+            SteamPlatformService.ReportSessionJoined();
+        }
+#endif
     }
 
     public void OnReadyClicked()
@@ -390,6 +408,14 @@ public class LobbyUIController : MonoBehaviour
         }
 
         SetStatusOverride(string.Format(m_Localization.InviteSentFormat, inviteCode.Trim()));
+
+#if STEAMWORKSNET
+        if (m_UsingSteam)
+        {
+            CSteamID lobbyId = m_SteamLobbyManager != null ? m_SteamLobbyManager.CurrentLobby : CSteamID.Nil;
+            SteamPlatformService.OpenInviteOverlay(lobbyId);
+        }
+#endif
     }
 
     private void OnReadyToggled(bool ready)
@@ -414,6 +440,13 @@ public class LobbyUIController : MonoBehaviour
         {
             m_ReadyToggle.isOn = ready;
         }
+
+#if STEAMWORKSNET
+        if (ready && m_UsingSteam)
+        {
+            SteamPlatformService.ReportReadyState();
+        }
+#endif
     }
 
     public void SubmitChat()

--- a/Puckslide/docs/steam_release_checklist.md
+++ b/Puckslide/docs/steam_release_checklist.md
@@ -1,0 +1,22 @@
+# Steam release verification checklist
+
+## Achievements and overlay
+- [x] Wire lobby host/join/ready flows into Steam achievements and stats through `SteamPlatformService` so first-time actions are tracked.
+- [x] Trigger Steam overlay invite dialogs from the lobby invite button when a Steam lobby is available; fall back to the friends overlay when no lobby exists.
+- [ ] Review in-game achievement IDs/strings in Steamworks to ensure they match `ACH_SESSION_HOST`, `ACH_SESSION_JOIN`, and `ACH_READY_UP`.
+- [ ] Validate overlay surfaces (friends, invites, achievements) in a Steam-enabled build.
+
+## Steam Cloud and platform builds
+- [ ] Confirm save data paths under `Application.persistentDataPath` are registered in Steam Cloud and available for Windows/macOS/Linux depots.
+- [ ] Validate depot manifests and platform icons/descriptions are present for every target build.
+- [ ] Exercise Steam Cloud conflict resolution once per platform to confirm uploads/downloads succeed.
+
+## Metadata and compliance
+- [ ] Re-run compliance checklist: ratings links, EULA, privacy policy, and support URLs accessible from the main menu and store page.
+- [ ] Verify store metadata (capsule images, screenshots, tags, and description) matches the current build number shown in the lobby UI.
+- [ ] Ensure GDPR/CCPA toggles (telemetry/crash reports) remain opt-in and reflected in crash/metrics services.
+
+## Load and network soak tests
+- [ ] Run automated lobby churn test for 60+ minutes using quickplay to monitor relay stability and packet loss.
+- [ ] Execute match-state soak test with repeated ready/start/reset cycles to validate resilience during reconnections.
+- [ ] Capture network diagnostics logs from `NetworkStatusHUD` and `ResilientSessionManager` for postmortem review.


### PR DESCRIPTION
## Summary
- add SteamPlatformService to centralize Steam achievements, stats, and overlay hooks
- wire lobby host/join/ready flows into Steam tracking and invite overlay calls
- document Steam release verification steps for metadata, compliance, and load testing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692237269714832fa1d68049adfe76f7)