### PR TITLE
Improve multiplayer orientation and setup controls

### DIFF
--- a/Puckslide/Assets/Scripts/Chess/BoardController.cs
+++ b/Puckslide/Assets/Scripts/Chess/BoardController.cs
@@ -440,7 +440,6 @@ public class BoardController : MonoBehaviour
         }
 
         m_LastMoveWasWhite = piece.IsWhite();
-        BoardFlipper.FlipCamera();
     }
 
     private Vector2Int GetCoords(Tile tile)

--- a/Puckslide/Assets/Scripts/Commands/LocalInputRouter.cs
+++ b/Puckslide/Assets/Scripts/Commands/LocalInputRouter.cs
@@ -14,6 +14,7 @@ public class LocalInputRouter : MonoBehaviour
     private int m_ActivePointerId = -1;
     private PlayerCommandTarget m_ActiveTarget = PlayerCommandTarget.Board;
     private int m_ActiveInstanceId = -1;
+    private bool m_InputLocked;
 
     private void Awake()
     {
@@ -28,9 +29,26 @@ public class LocalInputRouter : MonoBehaviour
         }
     }
 
+    private void OnEnable()
+    {
+        EventsManager.OnTurnChanged.AddListener(OnTurnChanged, true);
+        EventsManager.OnLobbySnapshot.AddListener(OnLobbySnapshot, true);
+    }
+
+    private void OnDisable()
+    {
+        EventsManager.OnTurnChanged.RemoveListener(OnTurnChanged);
+        EventsManager.OnLobbySnapshot.RemoveListener(OnLobbySnapshot);
+    }
+
     private void Update()
     {
         if (m_Dispatcher == null || m_Camera == null)
+        {
+            return;
+        }
+
+        if (m_InputLocked)
         {
             return;
         }
@@ -170,5 +188,15 @@ public class LocalInputRouter : MonoBehaviour
 
         worldPos = Vector3.zero;
         return false;
+    }
+
+    private void OnTurnChanged(bool isWhiteTurn)
+    {
+        m_InputLocked = isWhiteTurn != LobbyState.LocalIsWhitePlayer;
+    }
+
+    private void OnLobbySnapshot(LobbySnapshot _)
+    {
+        m_InputLocked = PuckController.IsWhiteTurn != LobbyState.LocalIsWhitePlayer;
     }
 }

--- a/Puckslide/Assets/Scripts/GameSetupManager.cs
+++ b/Puckslide/Assets/Scripts/GameSetupManager.cs
@@ -29,6 +29,15 @@ public class GameSetupManager : MonoBehaviour
     private const int MAX_PIECES_PER_COLOR = 16;
 
     public event Action CountsChanged;
+
+    [SerializeField]
+    private bool m_IsLocalHost = true;
+
+    [SerializeField]
+    private bool m_HostIsWhite = true;
+
+    [SerializeField]
+    private Toggle m_ColorToggle;
     
     [SerializeField]
     private PieceSetupData[] m_PieceSetup = new PieceSetupData[]
@@ -45,26 +54,58 @@ public class GameSetupManager : MonoBehaviour
     private GameObject m_Phase1Canvas;
     [SerializeField]
     private GameObject Phase1Environment;
-    
+
+    public bool IsLocalHost => m_IsLocalHost;
+
+    public bool HostIsWhite => m_HostIsWhite;
+
 
     private void OnEnable()
     {
+        LobbyState.SetLocalHost(m_IsLocalHost);
         EventsManager.OnDeletePucks.Invoke(true);
         PuckController.ResetTurnOrder();
 
-        m_PieceSetup = new PieceSetupData[]
+        EventsManager.OnLobbySnapshot.AddListener(OnLobbySnapshotReceived, true);
+
+        m_PieceSetup = LobbySnapshot.ClonePieceSetup(m_PieceSetup);
+
+        if (LobbyState.LatestSnapshot == null)
         {
-            new PieceSetupData { Type = ChessPieceType.Pawn,   WhiteCount=4, BlackCount=4, Sticky=true },
-            new PieceSetupData { Type = ChessPieceType.Knight, WhiteCount=1, BlackCount=1, Sticky=false },
-            new PieceSetupData { Type = ChessPieceType.Bishop, WhiteCount=1, BlackCount=1, Sticky=false },
-            new PieceSetupData { Type = ChessPieceType.Rook,   WhiteCount=1, BlackCount=1, Sticky=false },
-            new PieceSetupData { Type = ChessPieceType.Queen,  WhiteCount=1, BlackCount=1, Sticky=false },
-            new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=1, BlackCount=1, Sticky=true },
-        };
+            m_PieceSetup = new PieceSetupData[]
+            {
+                new PieceSetupData { Type = ChessPieceType.Pawn,   WhiteCount=4, BlackCount=4, Sticky=true },
+                new PieceSetupData { Type = ChessPieceType.Knight, WhiteCount=1, BlackCount=1, Sticky=false },
+                new PieceSetupData { Type = ChessPieceType.Bishop, WhiteCount=1, BlackCount=1, Sticky=false },
+                new PieceSetupData { Type = ChessPieceType.Rook,   WhiteCount=1, BlackCount=1, Sticky=false },
+                new PieceSetupData { Type = ChessPieceType.Queen,  WhiteCount=1, BlackCount=1, Sticky=false },
+                new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=1, BlackCount=1, Sticky=true },
+            };
+        }
+
+        if (m_ColorToggle != null)
+        {
+            m_ColorToggle.isOn = m_HostIsWhite;
+            m_ColorToggle.interactable = m_IsLocalHost;
+        }
+        NotifyCountsChanged();
+    }
+
+    private void OnDisable()
+    {
+        EventsManager.OnLobbySnapshot.RemoveListener(OnLobbySnapshotReceived);
     }
 
     public void StartButton()
     {
+        if (!m_IsLocalHost)
+        {
+            return;
+        }
+
+        LobbySnapshot snapshot = LobbySnapshot.Create(m_PieceSetup, m_HostIsWhite);
+        LobbyState.ApplySnapshot(snapshot);
+
         EventsManager.OnPieceSetupData.Invoke(m_PieceSetup);
         m_Phase1Canvas.SetActive(true);
         Phase1Environment.SetActive(true);
@@ -74,6 +115,11 @@ public class GameSetupManager : MonoBehaviour
 
     public bool IncreaseCount(ChessPieceType pieceType, bool isWhite)
     {
+        if (!m_IsLocalHost)
+        {
+            return false;
+        }
+
         PieceSetupData setupData = FindPieceSetupData(pieceType);
         if (setupData == null)
         {
@@ -103,6 +149,11 @@ public class GameSetupManager : MonoBehaviour
 
     public bool DecreaseCount(ChessPieceType pieceType, bool isWhite)
     {
+        if (!m_IsLocalHost)
+        {
+            return false;
+        }
+
         PieceSetupData setupData = FindPieceSetupData(pieceType);
         if (setupData == null)
         {
@@ -132,6 +183,11 @@ public class GameSetupManager : MonoBehaviour
 
     public void ToggleSticky(ChessPieceType pieceType, bool isSticky)
     {
+        if (!m_IsLocalHost)
+        {
+            return;
+        }
+
         for (int i = 0; i < m_PieceSetup.Length; i++)
         {
             if (m_PieceSetup[i].Type == pieceType)
@@ -170,6 +226,20 @@ public class GameSetupManager : MonoBehaviour
         return false;
     }
 
+    public void ToggleHostColor(bool wantsWhite)
+    {
+        if (!m_IsLocalHost)
+        {
+            return;
+        }
+
+        m_HostIsWhite = wantsWhite;
+        if (m_ColorToggle != null)
+        {
+            m_ColorToggle.isOn = m_HostIsWhite;
+        }
+    }
+
 
     public bool WithinWhiteCount()
     {
@@ -179,6 +249,24 @@ public class GameSetupManager : MonoBehaviour
     public bool WithinBlackCount()
     {
         return GetTotalCount(false) < MAX_PIECES_PER_COLOR;
+    }
+
+    private void OnLobbySnapshotReceived(LobbySnapshot snapshot)
+    {
+        if (snapshot == null)
+        {
+            return;
+        }
+
+        m_PieceSetup = LobbySnapshot.ClonePieceSetup(snapshot.PieceSetup);
+        m_HostIsWhite = snapshot.HostIsWhite;
+        if (m_ColorToggle != null)
+        {
+            m_ColorToggle.isOn = m_HostIsWhite;
+            m_ColorToggle.interactable = m_IsLocalHost;
+        }
+
+        NotifyCountsChanged();
     }
 
     public bool CanIncrease(ChessPieceType pieceType, bool isWhite)

--- a/Puckslide/Assets/Scripts/PuckController.cs
+++ b/Puckslide/Assets/Scripts/PuckController.cs
@@ -24,6 +24,12 @@ public class PuckController : MonoBehaviour
     [SerializeField]
     private float m_MaxDragMultiplier = 4f; // allowed pull distance in puck diameters
 
+    [SerializeField]
+    private float m_RemoteEntrySpeed = 4f;
+
+    [SerializeField]
+    private float m_RemoteFadeDuration = 0.15f;
+
     private Vector3 m_DragStartPos;
     private Camera m_Camera;
 
@@ -51,6 +57,7 @@ public class PuckController : MonoBehaviour
     private float m_BottomEntryY;
     private float m_TopEntryY;
     private float m_HalfBoardY;
+    private bool m_RemoteSpawnPositioned;
 
     private Vector3 m_StartPosition;
     private bool m_HasReachedBoard;
@@ -109,6 +116,7 @@ public class PuckController : MonoBehaviour
 
         UpdateBoardEntryLines();
         m_StartPosition = transform.position;
+        PositionForRemoteEntryIfNeeded();
     }
 
     // Recalculate the entry lines at the top and bottom of the board.
@@ -474,14 +482,6 @@ public class PuckController : MonoBehaviour
         {
             s_ActivePuck = null;
             s_IsWhiteTurn = !s_IsWhiteTurn;
-            if (Phase2Manager.IsPhase2Active)
-            {
-                BoardFlipper.FlipCamera();
-            }
-            else
-            {
-                yield return BoardFlipper.Flip();
-            }
             EventsManager.OnTurnChanged.Invoke(s_IsWhiteTurn);
         }
         else
@@ -502,6 +502,56 @@ public class PuckController : MonoBehaviour
         {
             m_HasReachedBoard = true;
         }
+    }
+
+    private void PositionForRemoteEntryIfNeeded()
+    {
+        if (Phase2Manager.IsPhase2Active)
+        {
+            return;
+        }
+
+        bool isRemotePlayerPiece = LobbyState.LocalIsWhitePlayer != IsWhitePiece;
+        if (!isRemotePlayerPiece || m_RemoteSpawnPositioned)
+        {
+            return;
+        }
+
+        float radius = m_Collider != null ? m_Collider.bounds.extents.y : 0.1f;
+        Vector3 spawnPos = transform.position;
+        spawnPos.y = m_TopEntryY + radius;
+        transform.position = spawnPos;
+        if (m_Rigidbody != null)
+        {
+            m_Rigidbody.position = spawnPos;
+            m_Rigidbody.velocity = Vector2.down * m_RemoteEntrySpeed;
+        }
+
+        if (m_RemoteFadeDuration > 0f && m_SpriteRenderer != null)
+        {
+            StartCoroutine(FadeInSprite());
+        }
+
+        m_RemoteSpawnPositioned = true;
+    }
+
+    private IEnumerator FadeInSprite()
+    {
+        float elapsed = 0f;
+        Color startColor = m_SpriteRenderer.color;
+        startColor.a = 0f;
+        Color endColor = m_SpriteRenderer.color;
+        m_SpriteRenderer.color = startColor;
+
+        while (elapsed < m_RemoteFadeDuration)
+        {
+            elapsed += Time.deltaTime;
+            float t = Mathf.Clamp01(elapsed / m_RemoteFadeDuration);
+            m_SpriteRenderer.color = Color.Lerp(startColor, endColor, t);
+            yield return null;
+        }
+
+        m_SpriteRenderer.color = endColor;
     }
 
     public Vector2Int CurrentGridPosition { get; private set; } // Store the grid position of this puck

--- a/Puckslide/Assets/Scripts/State/LobbyState.cs
+++ b/Puckslide/Assets/Scripts/State/LobbyState.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+
+[Serializable]
+public class LobbySnapshot
+{
+    public bool HostIsWhite = true;
+    public PieceSetupData[] PieceSetup = Array.Empty<PieceSetupData>();
+
+    public static LobbySnapshot Create(PieceSetupData[] setup, bool hostIsWhite)
+    {
+        return new LobbySnapshot
+        {
+            HostIsWhite = hostIsWhite,
+            PieceSetup = ClonePieceSetup(setup)
+        };
+    }
+
+    public static PieceSetupData[] ClonePieceSetup(PieceSetupData[] source)
+    {
+        if (source == null)
+        {
+            return Array.Empty<PieceSetupData>();
+        }
+
+        return source
+            .Select(piece => new PieceSetupData
+            {
+                Type = piece.Type,
+                WhiteCount = piece.WhiteCount,
+                BlackCount = piece.BlackCount,
+                Sticky = piece.Sticky
+            })
+            .ToArray();
+    }
+}
+
+public static class LobbyState
+{
+    private static LobbySnapshot s_LatestSnapshot;
+
+    public static bool LocalIsHost { get; private set; } = true;
+
+    public static bool LocalIsWhitePlayer
+    {
+        get
+        {
+            if (s_LatestSnapshot == null)
+            {
+                return true;
+            }
+
+            return LocalIsHost ? s_LatestSnapshot.HostIsWhite : !s_LatestSnapshot.HostIsWhite;
+        }
+    }
+
+    public static LobbySnapshot LatestSnapshot => s_LatestSnapshot;
+
+    public static void SetLocalHost(bool isHost)
+    {
+        LocalIsHost = isHost;
+    }
+
+    public static void ApplySnapshot(LobbySnapshot snapshot)
+    {
+        s_LatestSnapshot = snapshot;
+        EventsManager.OnLobbySnapshot.Invoke(snapshot);
+    }
+}

--- a/Puckslide/Assets/Scripts/UI/PieceSetupCounter.cs
+++ b/Puckslide/Assets/Scripts/UI/PieceSetupCounter.cs
@@ -63,7 +63,8 @@ public class PieceSetupCounter : MonoBehaviour
     {
         m_CurrentCount = m_GameSetupManager.GetCount(m_ChessPieceType, m_IsWhiteCounter);
         m_TextMeshProUGUI.text = $"{m_CurrentCount}";
-        m_MinusButton.interactable = m_GameSetupManager.CanDecrease(m_ChessPieceType, m_IsWhiteCounter);
-        m_PlusButton.interactable = m_GameSetupManager.CanIncrease(m_ChessPieceType, m_IsWhiteCounter);
+        bool canEdit = m_GameSetupManager != null && m_GameSetupManager.IsLocalHost;
+        m_MinusButton.interactable = canEdit && m_GameSetupManager.CanDecrease(m_ChessPieceType, m_IsWhiteCounter);
+        m_PlusButton.interactable = canEdit && m_GameSetupManager.CanIncrease(m_ChessPieceType, m_IsWhiteCounter);
     }
 }

--- a/Puckslide/Assets/Scripts/UI/StickySetup.cs
+++ b/Puckslide/Assets/Scripts/UI/StickySetup.cs
@@ -17,6 +17,7 @@ public class StickySetup : MonoBehaviour
     private void OnEnable()
     {
         m_StickyToggle.isOn = m_GameSetupManager.GetSticky(m_ChessPieceType);
+        m_StickyToggle.interactable = m_GameSetupManager.IsLocalHost;
         m_StickyToggle.onValueChanged.AddListener(OnToggle);
     }
     

--- a/Puckslide/Assets/Scripts/UI/TurnBannerHUD.cs
+++ b/Puckslide/Assets/Scripts/UI/TurnBannerHUD.cs
@@ -8,15 +8,6 @@ public class TurnBannerHUD : MonoBehaviour
     private TMP_Text m_PlayerLabel;
 
     [SerializeField]
-    private TMP_Text m_OrientationLabel;
-
-    [SerializeField]
-    private TMP_Text m_BannerArrow;
-
-    [SerializeField]
-    private TMP_Text m_MiniArrow;
-
-    [SerializeField]
     private float m_SlideDistance = 32f;
 
     [SerializeField]
@@ -25,11 +16,14 @@ public class TurnBannerHUD : MonoBehaviour
     [SerializeField]
     private float m_MinHoldDuration = 0.6f;
 
+    [SerializeField]
+    private CanvasGroup m_WaitingOverlay;
+
     private CanvasGroup m_CanvasGroup;
     private RectTransform m_RectTransform;
     private Coroutine m_AnimationRoutine;
     private Vector2 m_DefaultAnchoredPosition;
-    private bool m_IsFlipped;
+    private bool m_IsLocalTurn;
 
     private void Awake()
     {
@@ -43,24 +37,20 @@ public class TurnBannerHUD : MonoBehaviour
         {
             m_DefaultAnchoredPosition = m_RectTransform.anchoredPosition;
         }
-
-        if (m_OrientationLabel != null)
-        {
-            m_OrientationLabel.text = string.Empty;
-        }
     }
 
     private void OnEnable()
     {
-        EventsManager.OnBoardFlipState.AddListener(OnBoardFlipStateChanged, true);
         EventsManager.OnTurnChanged.AddListener(OnTurnChanged, true);
+        EventsManager.OnLobbySnapshot.AddListener(OnLobbySnapshot, true);
         UpdateLabels(PuckController.IsWhiteTurn);
+        ApplyMutedState();
     }
 
     private void OnDisable()
     {
-        EventsManager.OnBoardFlipState.RemoveListener(OnBoardFlipStateChanged);
         EventsManager.OnTurnChanged.RemoveListener(OnTurnChanged);
+        EventsManager.OnLobbySnapshot.RemoveListener(OnLobbySnapshot);
         if (m_AnimationRoutine != null)
         {
             StopCoroutine(m_AnimationRoutine);
@@ -68,19 +58,16 @@ public class TurnBannerHUD : MonoBehaviour
         }
     }
 
-    private void OnBoardFlipStateChanged(bool isFlipped)
-    {
-        m_IsFlipped = isFlipped;
-        UpdateLabels(PuckController.IsWhiteTurn);
-        UpdateArrows();
-        StartAnimationIfNeeded();
-    }
-
     private void OnTurnChanged(bool isWhiteTurn)
     {
         UpdateLabels(isWhiteTurn);
-        UpdateArrows();
+        ApplyMutedState();
         StartAnimationIfNeeded();
+    }
+
+    private void OnLobbySnapshot(LobbySnapshot _)
+    {
+        ApplyMutedState();
     }
 
     private void UpdateLabels(bool isWhiteTurn)
@@ -89,36 +76,6 @@ public class TurnBannerHUD : MonoBehaviour
         {
             m_PlayerLabel.text = isWhiteTurn ? "White's turn" : "Black's turn";
         }
-
-        if (m_OrientationLabel != null)
-        {
-            m_OrientationLabel.text = string.Empty;
-        }
-    }
-
-    private void UpdateArrows()
-    {
-        float zRotation = m_IsFlipped ? 180f : 0f;
-
-        if (m_BannerArrow != null)
-        {
-            RotateArrow(m_BannerArrow.rectTransform, zRotation);
-        }
-
-        if (m_MiniArrow != null)
-        {
-            RotateArrow(m_MiniArrow.rectTransform, zRotation);
-        }
-    }
-
-    private static void RotateArrow(RectTransform arrow, float zRotation)
-    {
-        if (arrow == null)
-        {
-            return;
-        }
-
-        arrow.localRotation = Quaternion.Euler(0f, 0f, zRotation);
     }
 
     private void StartAnimationIfNeeded()
@@ -158,8 +115,7 @@ public class TurnBannerHUD : MonoBehaviour
         m_RectTransform.anchoredPosition = m_DefaultAnchoredPosition;
         m_CanvasGroup.alpha = 1f;
 
-        float holdTime = Mathf.Max(BoardFlipper.GetFlipDuration(), m_MinHoldDuration);
-        yield return new WaitForSeconds(holdTime);
+        yield return new WaitForSeconds(m_MinHoldDuration);
 
         elapsed = 0f;
         while (elapsed < m_FadeDuration)
@@ -175,5 +131,17 @@ public class TurnBannerHUD : MonoBehaviour
         m_RectTransform.anchoredPosition = hiddenPosition;
         m_CanvasGroup.alpha = 0f;
         m_AnimationRoutine = null;
+    }
+
+    private void ApplyMutedState()
+    {
+        m_IsLocalTurn = PuckController.IsWhiteTurn == LobbyState.LocalIsWhitePlayer;
+
+        if (m_WaitingOverlay != null)
+        {
+            m_WaitingOverlay.alpha = m_IsLocalTurn ? 0f : 1f;
+            m_WaitingOverlay.blocksRaycasts = !m_IsLocalTurn;
+            m_WaitingOverlay.interactable = false;
+        }
     }
 }

--- a/Puckslide/Assets/Scripts/Util/EventsManager.cs
+++ b/Puckslide/Assets/Scripts/Util/EventsManager.cs
@@ -12,6 +12,7 @@ public static class EventsManager
     public static readonly Evt<Rigidbody2D> OnPuckDespawned = new Evt<Rigidbody2D>();
     public static readonly Evt<bool> OnTurnChanged = new Evt<bool>(true);
     public static readonly Evt<bool> OnBoardFlipState = new Evt<bool>();
+    public static readonly Evt<LobbySnapshot> OnLobbySnapshot = new Evt<LobbySnapshot>();
 }
 
 

--- a/Puckslide/QA_CHECKLIST.md
+++ b/Puckslide/QA_CHECKLIST.md
@@ -1,0 +1,6 @@
+# QA Checklist
+
+## Multiplayer reconnect
+- Rejoin an in-progress lobby and confirm the applied color assignment matches the host's choice.
+- Verify the waiting/muted state displays for the non-active player until the turn changes locally.
+- Observe an incoming remote shot after reconnect: the puck should spawn at the far/top edge without a launch animation, moving in from behind the entry wall.


### PR DESCRIPTION
## Summary
- remove turn-based camera/board flips and mute local input with a turn banner when waiting
- gate lobby setup controls to the host, include color assignment, and persist snapshots for reconnects
- support remote puck entry from the far edge and document reconnect QA steps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69223d189c6c832f9c5a226f251920ea)