### PR TITLE
Add lobby snapshot versioning and guest lobby UX notes

### DIFF
--- a/Puckslide/Assets/Scripts/GameSetupManager.cs
+++ b/Puckslide/Assets/Scripts/GameSetupManager.cs
@@ -55,6 +55,8 @@ public class GameSetupManager : MonoBehaviour
     private GameObject m_Phase1Canvas;
     [SerializeField]
     private GameObject Phase1Environment;
+    [SerializeField]
+    private Button m_StartButton;
 
     public bool IsLocalHost => m_IsLocalHost;
 
@@ -63,31 +65,33 @@ public class GameSetupManager : MonoBehaviour
 
     private void OnEnable()
     {
+        m_IsLocalHost = LobbyState.LocalIsHost;
         LobbyState.SetLocalHost(m_IsLocalHost);
         NetworkEvents.OnDeletePucks.Invoke(true);
         PuckController.ResetTurnOrder();
 
         NetworkEvents.OnLobbySnapshot.AddListener(OnLobbySnapshotReceived, true);
 
-        m_PieceSetup = LobbySnapshot.ClonePieceSetup(m_PieceSetup);
-
-        if (LobbyState.LatestLobbySnapshot == null)
+        LobbySnapshot latestSnapshot = LobbyState.LatestLobbySnapshot;
+        if (latestSnapshot != null)
         {
-            m_PieceSetup = new PieceSetupData[]
-            {
-                new PieceSetupData { Type = ChessPieceType.Pawn,   WhiteCount=4, BlackCount=4, Sticky=true },
-                new PieceSetupData { Type = ChessPieceType.Knight, WhiteCount=1, BlackCount=1, Sticky=false },
-                new PieceSetupData { Type = ChessPieceType.Bishop, WhiteCount=1, BlackCount=1, Sticky=false },
-                new PieceSetupData { Type = ChessPieceType.Rook,   WhiteCount=1, BlackCount=1, Sticky=false },
-                new PieceSetupData { Type = ChessPieceType.Queen,  WhiteCount=1, BlackCount=1, Sticky=false },
-                new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=1, BlackCount=1, Sticky=true },
-            };
+            m_PieceSetup = LobbySnapshot.ClonePieceSetup(latestSnapshot.PieceSetup);
+            m_HostIsWhite = latestSnapshot.HostIsWhite;
+        }
+        else
+        {
+            m_PieceSetup = LobbySnapshot.ClonePieceSetup(m_PieceSetup.Length == 0 ? CreateDefaultPieceSetup() : m_PieceSetup);
         }
 
         if (m_ColorToggle != null)
         {
             m_ColorToggle.isOn = m_HostIsWhite;
             m_ColorToggle.interactable = m_IsLocalHost;
+        }
+
+        if (m_StartButton != null)
+        {
+            m_StartButton.interactable = m_IsLocalHost;
         }
         NotifyCountsChanged();
     }
@@ -142,6 +146,7 @@ public class GameSetupManager : MonoBehaviour
         }
 
         NotifyCountsChanged();
+        BroadcastLocalSnapshot();
         return true;
     }
 
@@ -176,6 +181,7 @@ public class GameSetupManager : MonoBehaviour
         }
 
         NotifyCountsChanged();
+        BroadcastLocalSnapshot();
         return true;
     }
 
@@ -191,6 +197,8 @@ public class GameSetupManager : MonoBehaviour
             if (m_PieceSetup[i].Type == pieceType)
             {
                 m_PieceSetup[i].Sticky = isSticky;
+                NotifyCountsChanged();
+                BroadcastLocalSnapshot();
                 return;
             }
         }
@@ -236,6 +244,8 @@ public class GameSetupManager : MonoBehaviour
         {
             m_ColorToggle.isOn = m_HostIsWhite;
         }
+
+        BroadcastLocalSnapshot();
     }
 
 
@@ -256,12 +266,18 @@ public class GameSetupManager : MonoBehaviour
             return;
         }
 
+        m_IsLocalHost = LobbyState.LocalIsHost;
         m_PieceSetup = LobbySnapshot.ClonePieceSetup(snapshot.Snapshot.PieceSetup);
         m_HostIsWhite = snapshot.Snapshot.HostIsWhite;
         if (m_ColorToggle != null)
         {
             m_ColorToggle.isOn = m_HostIsWhite;
             m_ColorToggle.interactable = m_IsLocalHost;
+        }
+
+        if (m_StartButton != null)
+        {
+            m_StartButton.interactable = m_IsLocalHost;
         }
 
         NotifyCountsChanged();
@@ -318,5 +334,28 @@ public class GameSetupManager : MonoBehaviour
     private void NotifyCountsChanged()
     {
         CountsChanged?.Invoke();
+    }
+
+    private void BroadcastLocalSnapshot()
+    {
+        if (!m_IsLocalHost || NetworkSessionManager.Instance == null)
+        {
+            return;
+        }
+
+        NetworkSessionManager.Instance.BroadcastPieceSetup(m_PieceSetup, m_HostIsWhite);
+    }
+
+    private PieceSetupData[] CreateDefaultPieceSetup()
+    {
+        return new PieceSetupData[]
+        {
+            new PieceSetupData { Type = ChessPieceType.Pawn,   WhiteCount=4, BlackCount=4, Sticky=true },
+            new PieceSetupData { Type = ChessPieceType.Knight, WhiteCount=1, BlackCount=1, Sticky=false },
+            new PieceSetupData { Type = ChessPieceType.Bishop, WhiteCount=1, BlackCount=1, Sticky=false },
+            new PieceSetupData { Type = ChessPieceType.Rook,   WhiteCount=1, BlackCount=1, Sticky=false },
+            new PieceSetupData { Type = ChessPieceType.Queen,  WhiteCount=1, BlackCount=1, Sticky=false },
+            new PieceSetupData { Type = ChessPieceType.King,   WhiteCount=1, BlackCount=1, Sticky=true },
+        };
     }
 }

--- a/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
+++ b/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System;
 using System.Collections;
 using UnityEngine;
 
@@ -38,6 +37,7 @@ namespace Puckslide.Networking
         private ulong m_LocalPeerId;
         private bool m_IsHost;
         private string m_CurrentLobbyId;
+        private LobbySnapshot m_PersistedLobbySnapshot;
 
         public static NetworkSessionManager Instance => s_Instance;
         public bool IsHost => m_IsHost;
@@ -80,6 +80,11 @@ namespace Puckslide.Networking
             m_CurrentLobbyId = string.IsNullOrEmpty(lobbyId) ? m_CurrentLobbyId : lobbyId;
             LobbyState.SetLocalHost(true);
             m_SnapshotVersion = 0;
+            m_PersistedLobbySnapshot = LobbyState.LatestLobbySnapshot ?? new LobbySnapshot
+            {
+                HostIsWhite = LobbyState.LocalIsWhitePlayer,
+                PieceSetup = Array.Empty<PieceSetupData>()
+            };
             StartSnapshotLoop();
             PublishLobbySnapshot("host-created");
 
@@ -131,11 +136,14 @@ namespace Puckslide.Networking
                 return;
             }
 
-            LobbySnapshot latest = LobbyState.LatestLobbySnapshot ?? new LobbySnapshot
+            LobbySnapshot latest = m_PersistedLobbySnapshot ?? LobbyState.LatestLobbySnapshot ?? new LobbySnapshot
             {
                 HostIsWhite = LobbyState.LocalIsWhitePlayer,
                 PieceSetup = Array.Empty<PieceSetupData>()
             };
+
+            m_PersistedLobbySnapshot = LobbySnapshot.Create(latest.PieceSetup, latest.HostIsWhite);
+            m_SnapshotVersion = Math.Max(m_SnapshotVersion, LobbyState.LatestSnapshotVersion);
 
             NetworkLobbySnapshot snapshot = new NetworkLobbySnapshot
             {
@@ -158,6 +166,7 @@ namespace Puckslide.Networking
                 return;
             }
 
+            m_SnapshotVersion = Math.Max(m_SnapshotVersion, LobbyState.LatestSnapshotVersion);
             PieceSetupMessage message = new PieceSetupMessage
             {
                 LobbyId = m_CurrentLobbyId,
@@ -168,6 +177,7 @@ namespace Puckslide.Networking
             };
 
             LobbySnapshot snapshot = LobbySnapshot.Create(message.Setup, message.HostIsWhite);
+            m_PersistedLobbySnapshot = snapshot;
             LobbyState.ApplySnapshot(new NetworkLobbySnapshot
             {
                 LobbyId = message.LobbyId,
@@ -271,6 +281,10 @@ namespace Puckslide.Networking
 
             m_CurrentLobbyId = snapshot.LobbyId;
             LobbyState.ApplySnapshot(snapshot);
+            if (snapshot.HostPeerId == m_LocalPeerId)
+            {
+                m_SnapshotVersion = Math.Max(m_SnapshotVersion, snapshot.SnapshotVersion);
+            }
         }
 
         private void StartSnapshotLoop()

--- a/Puckslide/Assets/Scripts/State/LobbyState.cs
+++ b/Puckslide/Assets/Scripts/State/LobbyState.cs
@@ -44,6 +44,7 @@ public static class LobbyState
     public static ulong LocalPeerId { get; private set; }
     public static NetworkLobbySnapshot LatestNetworkSnapshot => s_LatestSnapshot;
     public static LobbySnapshot LatestLobbySnapshot => s_LatestSnapshot?.Snapshot;
+    public static uint LatestSnapshotVersion => s_LatestSnapshot?.SnapshotVersion ?? 0u;
 
     public static bool LocalIsWhitePlayer
     {
@@ -83,6 +84,12 @@ public static class LobbyState
                 HostIsWhite = true,
                 PieceSetup = Array.Empty<PieceSetupData>()
             };
+        }
+
+        bool isNewLobby = s_LatestSnapshot == null || s_LatestSnapshot.LobbyId != snapshot.LobbyId;
+        if (!isNewLobby && snapshot.SnapshotVersion <= s_LatestSnapshot.SnapshotVersion)
+        {
+            return;
         }
 
         s_LatestSnapshot = snapshot;

--- a/Puckslide/Assets/Scripts/UI/StickySetup.cs
+++ b/Puckslide/Assets/Scripts/UI/StickySetup.cs
@@ -16,18 +16,30 @@ public class StickySetup : MonoBehaviour
 
     private void OnEnable()
     {
-        m_StickyToggle.isOn = m_GameSetupManager.GetSticky(m_ChessPieceType);
-        m_StickyToggle.interactable = m_GameSetupManager.IsLocalHost;
+        Refresh();
+        m_GameSetupManager.CountsChanged += Refresh;
         m_StickyToggle.onValueChanged.AddListener(OnToggle);
     }
-    
+
     private void OnDisable()
     {
         m_StickyToggle.onValueChanged.RemoveListener(OnToggle);
+        m_GameSetupManager.CountsChanged -= Refresh;
     }
 
     private void OnToggle(bool isActive)
     {
         m_GameSetupManager.ToggleSticky(m_ChessPieceType, isActive);
+    }
+
+    private void Refresh()
+    {
+        if (m_GameSetupManager == null)
+        {
+            return;
+        }
+
+        m_StickyToggle.isOn = m_GameSetupManager.GetSticky(m_ChessPieceType);
+        m_StickyToggle.interactable = m_GameSetupManager.IsLocalHost;
     }
 }

--- a/Puckslide/LobbyUXExpectations.md
+++ b/Puckslide/LobbyUXExpectations.md
@@ -1,0 +1,28 @@
+# Lobby & Countdown UX Expectations
+
+These notes capture the current interaction model so client and host UIs can mirror behavior during networking work.
+
+## Lobby roles
+- Two-player lobby with a single host (Player 1) and guest (Player 2).
+- Host sees fully interactive controls; guest sees the same controls but disabled/greyed out with an optional tooltip "Only the host can change settings." when they try to interact.
+- Status label examples: "You are the HOST/GUEST", "Waiting for guest to join…", "Guest connected."
+
+## Snapshot behavior
+- Host is authoritative. Every change the host makes to colors/skins, board layout, or rules increments `LobbySnapshot.version` and is sent to the guest.
+- Guests always render the most recent snapshot they have; stale snapshots (lower version) are ignored.
+- Late joiners during the lobby immediately receive the latest snapshot and see an informative line such as "Joined lobby – waiting for host to start.".
+
+## Countdown & start
+- Host presses **Start Match** to trigger a shared countdown (e.g., 3→2→1→Go!).
+- While the countdown runs, all lobby inputs are disabled for both players.
+- If the countdown is canceled (disconnect, etc.), controls re-enable and a brief message such as "Countdown canceled – player left the lobby." is shown.
+- Late-joining during a countdown is allowed; the guest sees the in-progress number and cannot change any settings.
+
+## Disconnects and re-entry
+- No host migration in v1; if the host disconnects, the guest is returned to the main menu with a message like "Host disconnected – match ended.".
+- Guest disconnect during match: host can stay to view the board or exit.
+- Reconnects during a lobby use the persisted `LobbySnapshot`; in-match reconnects are not supported in v1.
+- Late join during an active match is blocked with a simple message (e.g., "This match is already in progress. Please wait for the next game."), possibly redirecting back to matchmaking.
+
+## Visual feedback
+- Keep a small, always-on status label updated with lobby state messages such as "Match starting in 3…" or "Host disconnected – returning to menu…".


### PR DESCRIPTION
## Summary
- broadcast lobby setup snapshots whenever the host changes counts, stickiness, or color selection and keep guest controls locked
- persist and version lobby snapshots on the host side to ignore stale updates and rebroadcast during snapshot loops
- document lobby and countdown UX expectations for late joiners, disconnects, and control locking

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692242209a60832f9ed5c1f3a50bb66b)