### PR TITLE
Add authoritative puck networking and determinism safeguards

### DIFF
--- a/Puckslide/Assets/Scripts/Commands/LocalInputRouter.cs
+++ b/Puckslide/Assets/Scripts/Commands/LocalInputRouter.cs
@@ -62,7 +62,7 @@ public class LocalInputRouter : MonoBehaviour
         if (TryGetPointerDown(out Vector3 pointerDownPos, out int pointerId))
         {
             PlayerCommand command = BuildPointerCommand(pointerDownPos, pointerId, PlayerCommandType.PointerDown);
-            m_Dispatcher.Enqueue(command);
+            SubmitCommand(command);
             m_IsPointerActive = true;
             m_ActivePointerId = pointerId;
         }
@@ -70,13 +70,13 @@ public class LocalInputRouter : MonoBehaviour
         if (m_IsPointerActive && TryGetPointerPosition(out Vector3 pointerPos))
         {
             PlayerCommand command = BuildPointerCommand(pointerPos, m_ActivePointerId, PlayerCommandType.PointerDrag);
-            m_Dispatcher.Enqueue(command);
+            SubmitCommand(command);
         }
 
         if (m_IsPointerActive && TryGetPointerUp(out Vector3 pointerUpPos))
         {
             PlayerCommand command = BuildPointerCommand(pointerUpPos, m_ActivePointerId, PlayerCommandType.PointerUp);
-            m_Dispatcher.Enqueue(command);
+            SubmitCommand(command);
             m_IsPointerActive = false;
             m_ActivePointerId = -1;
             m_ActiveInstanceId = -1;
@@ -98,6 +98,18 @@ public class LocalInputRouter : MonoBehaviour
             m_ActiveTarget,
             m_ActiveInstanceId,
             worldPos);
+    }
+
+    private void SubmitCommand(PlayerCommand command)
+    {
+        NetworkSessionManager manager = NetworkSessionManager.Instance;
+        if (manager != null)
+        {
+            manager.SubmitPlayerCommand(command);
+            return;
+        }
+
+        m_Dispatcher?.Enqueue(command);
     }
 
     private void IdentifyTarget(Vector3 worldPos)

--- a/Puckslide/Assets/Scripts/Commands/PuckControllerRouteHub.cs
+++ b/Puckslide/Assets/Scripts/Commands/PuckControllerRouteHub.cs
@@ -20,6 +20,11 @@ public static class PuckControllerRouteHub
         }
     }
 
+    public static bool TryGet(int instanceId, out PuckController controller)
+    {
+        return s_Pucks.TryGetValue(instanceId, out controller);
+    }
+
     public static void Process(PlayerCommand command)
     {
         if (!s_Pucks.TryGetValue(command.TargetInstanceId, out PuckController controller))

--- a/Puckslide/Assets/Scripts/Networking/NetworkEvents.cs
+++ b/Puckslide/Assets/Scripts/Networking/NetworkEvents.cs
@@ -22,6 +22,9 @@ namespace Puckslide.Networking
         public static readonly NetworkEvt<PuckSpawnMessage> OnNetworkPuckSpawned = new NetworkEvt<PuckSpawnMessage>();
         public static readonly NetworkEvt<PuckDespawnMessage> OnNetworkPuckDespawned = new NetworkEvt<PuckDespawnMessage>();
         public static readonly NetworkEvt<ShotLaunchMessage> OnShotLaunched = new NetworkEvt<ShotLaunchMessage>();
+        public static readonly NetworkEvt<PlayerCommandMessage> OnPlayerCommandSubmitted = new NetworkEvt<PlayerCommandMessage>();
+        public static readonly NetworkEvt<PuckStateSnapshotMessage> OnPuckSnapshot = new NetworkEvt<PuckStateSnapshotMessage>();
+        public static readonly NetworkEvt<TurnDeterminismMessage> OnTurnDeterminism = new NetworkEvt<TurnDeterminismMessage>();
     }
 
     public class NetworkEvt<T>

--- a/Puckslide/Assets/Scripts/Networking/NetworkMessages.cs
+++ b/Puckslide/Assets/Scripts/Networking/NetworkMessages.cs
@@ -66,4 +66,34 @@ namespace Puckslide.Networking
         public double ClientTime;
         public double ServerTime;
     }
+
+    [Serializable]
+    public class PlayerCommandMessage
+    {
+        public string LobbyId;
+        public PlayerCommand Command;
+        public double ClientTime;
+        public double ServerTime;
+    }
+
+    [Serializable]
+    public class PuckStateSnapshotMessage
+    {
+        public string LobbyId;
+        public bool IsWhiteTurn;
+        public uint TurnNumber;
+        public bool IsPhase2Active;
+        public PuckState[] Pucks;
+        public double ServerTime;
+    }
+
+    [Serializable]
+    public class TurnDeterminismMessage
+    {
+        public string LobbyId;
+        public uint TurnNumber;
+        public int RandomSeed;
+        public GameStateSnapshot Snapshot;
+        public double ServerTime;
+    }
 }

--- a/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
+++ b/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 #if MIRROR
@@ -21,6 +22,14 @@ namespace Puckslide.Networking
         private float m_SnapshotIntervalSeconds = 3f;
         [SerializeField]
         private bool m_StartAsHost = true;
+        [SerializeField]
+        private float m_PuckSnapshotInterval = 0.25f;
+        [SerializeField]
+        private float m_AcceptableLatencyMs = 150f;
+        [SerializeField]
+        private float m_AcceptablePacketLossPercent = 1.5f;
+        [SerializeField]
+        private int m_MaxTurnHistory = 5;
 
 #if MIRROR
         [SerializeField]
@@ -33,11 +42,15 @@ namespace Puckslide.Networking
 
         private static NetworkSessionManager s_Instance;
         private Coroutine m_SnapshotRoutine;
+        private Coroutine m_PuckSnapshotRoutine;
         private uint m_SnapshotVersion;
         private ulong m_LocalPeerId;
         private bool m_IsHost;
         private string m_CurrentLobbyId;
         private LobbySnapshot m_PersistedLobbySnapshot;
+        private readonly List<TurnDeterminismMessage> m_TurnHistory = new List<TurnDeterminismMessage>();
+        private PlayerCommandDispatcher m_Dispatcher;
+        private GridManager m_GridManager;
 
         public static NetworkSessionManager Instance => s_Instance;
         public bool IsHost => m_IsHost;
@@ -55,6 +68,10 @@ namespace Puckslide.Networking
             m_CurrentLobbyId = string.IsNullOrEmpty(m_DefaultLobbyId) ? Guid.NewGuid().ToString("N") : m_DefaultLobbyId;
             m_LocalPeerId = (ulong)UnityEngine.Random.Range(int.MinValue, int.MaxValue);
             LobbyState.SetLocalPeerId(m_LocalPeerId);
+
+            m_Dispatcher = PlayerCommandDispatcher.Instance ?? FindObjectOfType<PlayerCommandDispatcher>();
+            m_GridManager = FindObjectOfType<GridManager>();
+            Debug.Log($"Networking tolerances — latency: {m_AcceptableLatencyMs}ms, loss: {m_AcceptablePacketLossPercent}%.");
         }
 
         private void OnEnable()
@@ -63,6 +80,9 @@ namespace Puckslide.Networking
             {
                 CreateLobby();
             }
+
+            NetworkEvents.OnPlayerCommandSubmitted.AddListener(OnPlayerCommandSubmitted);
+            NetworkEvents.OnTurnChanged.AddListener(OnTurnChangedForDeterminism, true);
         }
 
         private void OnDisable()
@@ -72,6 +92,15 @@ namespace Puckslide.Networking
                 StopCoroutine(m_SnapshotRoutine);
                 m_SnapshotRoutine = null;
             }
+
+            if (m_PuckSnapshotRoutine != null)
+            {
+                StopCoroutine(m_PuckSnapshotRoutine);
+                m_PuckSnapshotRoutine = null;
+            }
+
+            NetworkEvents.OnPlayerCommandSubmitted.RemoveListener(OnPlayerCommandSubmitted);
+            NetworkEvents.OnTurnChanged.RemoveListener(OnTurnChangedForDeterminism);
         }
 
         public void CreateLobby(string lobbyId = null)
@@ -86,6 +115,7 @@ namespace Puckslide.Networking
                 PieceSetup = Array.Empty<PieceSetupData>()
             };
             StartSnapshotLoop();
+            StartPuckSnapshotLoop();
             PublishLobbySnapshot("host-created");
 
 #if MIRROR
@@ -102,6 +132,7 @@ namespace Puckslide.Networking
             m_CurrentLobbyId = lobbyId;
             LobbyState.SetLocalHost(false);
             StopSnapshotLoop();
+            StopPuckSnapshotLoop();
 
 #if MIRROR
             if (m_NetworkManager != null)
@@ -121,10 +152,12 @@ namespace Puckslide.Networking
             {
                 PublishLobbySnapshot("host-migrated");
                 StartSnapshotLoop();
+                StartPuckSnapshotLoop();
             }
             else
             {
                 StopSnapshotLoop();
+                StopPuckSnapshotLoop();
             }
         }
 
@@ -209,6 +242,7 @@ namespace Puckslide.Networking
             };
 
             NetworkEvents.OnTurnChanged.Invoke(message);
+            PublishDeterminismSnapshot(turnNumber);
         }
 
         public void BroadcastPuckSpawn(PuckController puck, string spawnReason)
@@ -272,6 +306,32 @@ namespace Puckslide.Networking
             NetworkEvents.OnShotLaunched.Invoke(message);
         }
 
+        public void SubmitPlayerCommand(PlayerCommand command)
+        {
+            if (command.CommandType == PlayerCommandType.PointerUp && command.Target == PlayerCommandTarget.Puck)
+            {
+                TryApplyCommandAsHost(command);
+                return;
+            }
+
+            if (!m_IsHost)
+            {
+                PlayerCommandMessage message = new PlayerCommandMessage
+                {
+                    LobbyId = m_CurrentLobbyId,
+                    Command = command,
+                    ClientTime = Time.unscaledTimeAsDouble,
+                    ServerTime = 0d
+                };
+
+                NetworkEvents.OnPlayerCommandSubmitted.Invoke(message);
+            }
+            else
+            {
+                TryApplyCommandAsHost(command);
+            }
+        }
+
         public void ReceiveSnapshot(NetworkLobbySnapshot snapshot)
         {
             if (snapshot == null)
@@ -296,6 +356,15 @@ namespace Puckslide.Networking
             }
         }
 
+        private void StartPuckSnapshotLoop()
+        {
+            StopPuckSnapshotLoop();
+            if (m_PuckSnapshotInterval > 0f)
+            {
+                m_PuckSnapshotRoutine = StartCoroutine(SendPuckSnapshots());
+            }
+        }
+
         private void StopSnapshotLoop()
         {
             if (m_SnapshotRoutine != null)
@@ -305,12 +374,132 @@ namespace Puckslide.Networking
             }
         }
 
+        private void StopPuckSnapshotLoop()
+        {
+            if (m_PuckSnapshotRoutine != null)
+            {
+                StopCoroutine(m_PuckSnapshotRoutine);
+                m_PuckSnapshotRoutine = null;
+            }
+        }
+
         private IEnumerator SendSnapshots()
         {
             while (true)
             {
                 PublishLobbySnapshot("heartbeat");
                 yield return new WaitForSeconds(m_SnapshotIntervalSeconds);
+            }
+        }
+
+        private IEnumerator SendPuckSnapshots()
+        {
+            while (true)
+            {
+                PublishPuckSnapshot();
+                yield return new WaitForSeconds(m_PuckSnapshotInterval);
+            }
+        }
+
+        private void PublishPuckSnapshot()
+        {
+            if (!m_IsHost)
+            {
+                return;
+            }
+
+            GameStateSnapshot snapshot = GameStateSnapshot.Capture(m_GridManager);
+            PuckStateSnapshotMessage message = new PuckStateSnapshotMessage
+            {
+                LobbyId = m_CurrentLobbyId,
+                IsWhiteTurn = snapshot.IsWhiteTurn,
+                TurnNumber = PuckController.TurnNumber,
+                IsPhase2Active = snapshot.IsPhase2Active,
+                Pucks = snapshot.Pucks.ToArray(),
+                ServerTime = Time.unscaledTimeAsDouble
+            };
+
+            NetworkEvents.OnPuckSnapshot.Invoke(message);
+        }
+
+        private void OnPlayerCommandSubmitted(PlayerCommandMessage message)
+        {
+            if (!m_IsHost || message == null || message.LobbyId != m_CurrentLobbyId)
+            {
+                return;
+            }
+
+            TryApplyCommandAsHost(message.Command);
+        }
+
+        private void TryApplyCommandAsHost(PlayerCommand command)
+        {
+            if (!m_IsHost && command.CommandType == PlayerCommandType.PointerUp)
+            {
+                return;
+            }
+
+            if (command.Target == PlayerCommandTarget.Puck && !ValidatePuckTurn(command.TargetInstanceId))
+            {
+                Debug.LogWarning($"Rejected command for puck {command.TargetInstanceId} — not active player's turn.");
+                return;
+            }
+
+            if (m_Dispatcher == null)
+            {
+                m_Dispatcher = PlayerCommandDispatcher.Instance ?? FindObjectOfType<PlayerCommandDispatcher>();
+            }
+
+            if (m_Dispatcher == null)
+            {
+                Debug.LogWarning("No PlayerCommandDispatcher found to process commands.");
+                return;
+            }
+
+            m_Dispatcher.Enqueue(command);
+        }
+
+        private bool ValidatePuckTurn(int targetInstanceId)
+        {
+            if (!PuckControllerRouteHub.TryGet(targetInstanceId, out PuckController puck))
+            {
+                return false;
+            }
+
+            return puck.IsWhitePiece == PuckController.IsWhiteTurn;
+        }
+
+        private void PublishDeterminismSnapshot(uint turnNumber)
+        {
+            if (!m_IsHost)
+            {
+                return;
+            }
+
+            GameStateSnapshot snapshot = GameStateSnapshot.Capture(m_GridManager);
+            TurnDeterminismMessage message = new TurnDeterminismMessage
+            {
+                LobbyId = m_CurrentLobbyId,
+                TurnNumber = turnNumber,
+                RandomSeed = UnityEngine.Random.Range(int.MinValue, int.MaxValue),
+                Snapshot = snapshot,
+                ServerTime = Time.unscaledTimeAsDouble
+            };
+
+            m_TurnHistory.Add(message);
+            while (m_TurnHistory.Count > m_MaxTurnHistory)
+            {
+                m_TurnHistory.RemoveAt(0);
+            }
+
+            NetworkEvents.OnTurnDeterminism.Invoke(message);
+        }
+
+        private void OnTurnChangedForDeterminism(TurnChangeMessage _)
+        {
+            if (m_IsHost)
+            {
+                PublishPuckSnapshot();
             }
         }
     }

--- a/Puckslide/Assets/Scripts/Networking/PuckStateReplicator.cs
+++ b/Puckslide/Assets/Scripts/Networking/PuckStateReplicator.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Puckslide.Networking
+{
+    public class PuckStateReplicator : MonoBehaviour
+    {
+        [SerializeField]
+        private float m_PositionLerpSpeed = 10f;
+        [SerializeField]
+        private float m_VelocityLerpSpeed = 6f;
+
+        private readonly Dictionary<int, PuckState> m_TargetStates = new Dictionary<int, PuckState>();
+
+        private void OnEnable()
+        {
+            NetworkEvents.OnPuckSnapshot.AddListener(OnSnapshot);
+            NetworkEvents.OnNetworkPuckSpawned.AddListener(OnSpawned);
+        }
+
+        private void OnDisable()
+        {
+            NetworkEvents.OnPuckSnapshot.RemoveListener(OnSnapshot);
+            NetworkEvents.OnNetworkPuckSpawned.RemoveListener(OnSpawned);
+            m_TargetStates.Clear();
+        }
+
+        private void Update()
+        {
+            NetworkSessionManager manager = NetworkSessionManager.Instance;
+            if (manager != null && manager.IsHost)
+            {
+                return;
+            }
+
+            foreach (KeyValuePair<int, PuckState> kvp in m_TargetStates)
+            {
+                if (!PuckControllerRouteHub.TryGet(kvp.Key, out PuckController controller))
+                {
+                    continue;
+                }
+
+                Rigidbody2D body = controller.Rigidbody;
+                if (body == null)
+                {
+                    continue;
+                }
+
+                body.position = Vector2.Lerp(body.position, kvp.Value.Position, Time.deltaTime * m_PositionLerpSpeed);
+                body.velocity = Vector2.Lerp(body.velocity, kvp.Value.Velocity, Time.deltaTime * m_VelocityLerpSpeed);
+                body.angularVelocity = kvp.Value.AngularVelocity;
+                controller.transform.rotation = Quaternion.Euler(0f, 0f, kvp.Value.RotationZ);
+            }
+        }
+
+        private void OnSnapshot(PuckStateSnapshotMessage message)
+        {
+            NetworkSessionManager manager = NetworkSessionManager.Instance;
+            if (manager != null && manager.IsHost)
+            {
+                return;
+            }
+
+            if (message == null || message.Pucks == null)
+            {
+                return;
+            }
+
+            m_TargetStates.Clear();
+            foreach (PuckState state in message.Pucks)
+            {
+                m_TargetStates[state.InstanceId] = state;
+            }
+        }
+
+        private void OnSpawned(PuckSpawnMessage message)
+        {
+            NetworkSessionManager manager = NetworkSessionManager.Instance;
+            if (manager != null && manager.IsHost)
+            {
+                return;
+            }
+
+            if (message == null)
+            {
+                return;
+            }
+
+            if (PuckControllerRouteHub.TryGet(message.NetworkInstanceId, out PuckController controller))
+            {
+                Rigidbody2D body = controller.Rigidbody;
+                if (body != null)
+                {
+                    body.position = message.Position;
+                    body.velocity = message.Velocity;
+                    controller.transform.position = message.Position;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Route puck pointer input through the host for validation and dispatch while publishing per-turn determinism snapshots and seeds
- Broadcast regular authoritative puck state snapshots and add client-side replication/interpolation for transforms and deterministic remote spawns
- Surface configured latency/packet-loss tolerances to guide snapshot cadence choices

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69224345e08c832f8b332a6ab7e92386)