### PR TITLE
Send client player commands to host via Mirror

### DIFF
--- a/Puckslide/Assets/Scripts/Networking/MirrorNetworkBridge.cs
+++ b/Puckslide/Assets/Scripts/Networking/MirrorNetworkBridge.cs
@@ -45,6 +45,24 @@ namespace Puckslide.Networking
 
         private bool IsHost => Session != null && Session.IsHost;
 
+        /// <summary>
+        /// Called by non-host clients to send a PlayerCommandMessage to the host.
+        /// </summary>
+        public void SendPlayerCommand(PlayerCommandMessage message)
+        {
+            // Clients only
+            if (!NetworkClient.active || NetworkServer.active)
+            {
+                // Either not connected or we are the host; do nothing here.
+                return;
+            }
+
+            NetworkClient.Send(new MirrorPlayerCommandMessage
+            {
+                Command = message
+            });
+        }
+
         private void RegisterClientHandlers()
         {
             NetworkClient.RegisterHandler<MirrorLobbySnapshotMessage>(OnMirrorLobbySnapshotReceived);
@@ -211,7 +229,25 @@ namespace Puckslide.Networking
 
         private void OnMirrorPlayerCommandReceived(NetworkConnectionToClient conn, MirrorPlayerCommandMessage msg)
         {
-            NetworkEvents.OnPlayerCommandSubmitted.Invoke(msg.Command);
+            // Server-only: this should only run on host.
+            if (!NetworkServer.active)
+            {
+                return;
+            }
+
+            PlayerCommandMessage commandMessage = msg.Command;
+
+            // Optional validation against current lobby.
+            NetworkSessionManager manager = NetworkSessionManager.Instance;
+            if (manager != null && !string.IsNullOrEmpty(manager.LobbyId))
+            {
+                if (commandMessage.LobbyId != manager.LobbyId)
+                {
+                    return;
+                }
+            }
+
+            NetworkEvents.OnPlayerCommandSubmitted.Invoke(commandMessage);
         }
     }
 }

--- a/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
+++ b/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
@@ -320,28 +320,35 @@ namespace Puckslide.Networking
 
         public void SubmitPlayerCommand(PlayerCommand command)
         {
-            if (command.CommandType == PlayerCommandType.PointerUp && command.Target == PlayerCommandTarget.Puck)
+            // Host: apply command directly into the simulation.
+            if (m_IsHost)
             {
                 TryApplyCommandAsHost(command);
                 return;
             }
 
-            if (!m_IsHost)
+            // Client: wrap into a PlayerCommandMessage
+            PlayerCommandMessage message = new PlayerCommandMessage
             {
-                PlayerCommandMessage message = new PlayerCommandMessage
-                {
-                    LobbyId = m_CurrentLobbyId,
-                    Command = command,
-                    ClientTime = Time.unscaledTimeAsDouble,
-                    ServerTime = 0d
-                };
+                LobbyId = m_CurrentLobbyId,
+                Command = command,
+                ClientTime = Time.unscaledTimeAsDouble,
+                ServerTime = 0d
+            };
 
-                NetworkEvents.OnPlayerCommandSubmitted.Invoke(message);
-            }
-            else
+#if MIRROR
+            // If we have a Mirror bridge and a live client connection,
+            // send the command to the host over the network.
+            if (MirrorNetworkBridge.Instance != null)
             {
-                TryApplyCommandAsHost(command);
+                MirrorNetworkBridge.Instance.SendPlayerCommand(message);
+                return;
             }
+#endif
+
+            // Fallback path (no Mirror / offline testing): behave as before,
+            // delivering the message directly into the host event handler.
+            NetworkEvents.OnPlayerCommandSubmitted.Invoke(message);
         }
 
         public void ReceiveSnapshot(NetworkLobbySnapshot snapshot)


### PR DESCRIPTION
## Summary
- add a MirrorNetworkBridge API for sending player commands from clients and validate host receipt
- route client player command submissions through Mirror with fallback to local handling when Mirror is unavailable

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ee031238832fba55fee63b00ccd4)