### PR TITLE
Sync host lobby and puck snapshots to clients

### DIFF
--- a/Puckslide/Assets/Scripts/Networking/MirrorNetworkBridge.cs
+++ b/Puckslide/Assets/Scripts/Networking/MirrorNetworkBridge.cs
@@ -134,12 +134,22 @@ namespace Puckslide.Networking
                 return;
             }
 
+            if (!NetworkServer.active)
+            {
+                return;
+            }
+
             NetworkServer.SendToAll(new MirrorLobbySnapshotMessage { Snapshot = snapshot });
         }
 
         private void OnPuckSnapshotBroadcasted(PuckStateSnapshotMessage snapshot)
         {
             if (!IsHost || snapshot == null)
+            {
+                return;
+            }
+
+            if (!NetworkServer.active)
             {
                 return;
             }
@@ -199,7 +209,7 @@ namespace Puckslide.Networking
 
         private void OnMirrorLobbySnapshotReceived(NetworkConnection conn, MirrorLobbySnapshotMessage msg)
         {
-            NetworkEvents.OnLobbySnapshot.Invoke(msg.Snapshot);
+            LobbyState.ApplySnapshot(msg.Snapshot);
         }
 
         private void OnMirrorPuckSnapshotReceived(NetworkConnection conn, MirrorPuckSnapshotMessage msg)

--- a/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
+++ b/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
@@ -203,6 +203,26 @@ namespace Puckslide.Networking
             LobbyState.ApplySnapshot(snapshot);
         }
 
+        public void UpdateHostPieceSetup(PieceSetupData[] setupData, bool? hostIsWhiteOverride = null)
+        {
+            if (!m_IsHost)
+            {
+                Debug.LogWarning("Only host should call UpdateHostPieceSetup.");
+                return;
+            }
+
+            LobbySnapshot latest = m_PersistedLobbySnapshot ?? LobbyState.LatestLobbySnapshot ?? new LobbySnapshot
+            {
+                HostIsWhite = LobbyState.LocalIsWhitePlayer,
+                PieceSetup = Array.Empty<PieceSetupData>()
+            };
+
+            bool hostIsWhite = hostIsWhiteOverride ?? latest.HostIsWhite;
+            m_PersistedLobbySnapshot = LobbySnapshot.Create(setupData, hostIsWhite);
+
+            PublishLobbySnapshot("piece-setup-updated");
+        }
+
         public void BroadcastPieceSetup(PieceSetupData[] setup, bool hostIsWhite)
         {
             if (!m_IsHost)
@@ -211,27 +231,17 @@ namespace Puckslide.Networking
                 return;
             }
 
+            UpdateHostPieceSetup(setup, hostIsWhite);
+
             m_SnapshotVersion = Math.Max(m_SnapshotVersion, LobbyState.LatestSnapshotVersion);
             PieceSetupMessage message = new PieceSetupMessage
             {
                 LobbyId = m_CurrentLobbyId,
                 Setup = LobbySnapshot.ClonePieceSetup(setup),
                 HostIsWhite = hostIsWhite,
-                Version = ++m_SnapshotVersion,
+                Version = m_SnapshotVersion,
                 ServerTime = Time.unscaledTimeAsDouble
             };
-
-            LobbySnapshot snapshot = LobbySnapshot.Create(message.Setup, message.HostIsWhite);
-            m_PersistedLobbySnapshot = snapshot;
-            LobbyState.ApplySnapshot(new NetworkLobbySnapshot
-            {
-                LobbyId = message.LobbyId,
-                Snapshot = snapshot,
-                HostIsAuthoritative = m_IsHost,
-                HostPeerId = m_LocalPeerId,
-                SnapshotVersion = message.Version,
-                ServerTime = message.ServerTime
-            });
 
             NetworkEvents.OnPieceSetupData.Invoke(message);
         }

--- a/Puckslide/Assets/Scripts/Networking/PuckStateReplicator.cs
+++ b/Puckslide/Assets/Scripts/Networking/PuckStateReplicator.cs
@@ -14,6 +14,12 @@ namespace Puckslide.Networking
 
         private void OnEnable()
         {
+            NetworkSessionManager manager = NetworkSessionManager.Instance;
+            if (manager != null && manager.IsHost)
+            {
+                return;
+            }
+
             NetworkEvents.OnPuckSnapshot.AddListener(OnSnapshot);
             NetworkEvents.OnNetworkPuckSpawned.AddListener(OnSpawned);
         }


### PR DESCRIPTION
## Summary
- guard Mirror broadcasts behind an active server and apply lobby snapshots received over the network
- add host piece-setup update flow that feeds lobby snapshot publishing and reuse it from broadcasts
- skip puck interpolation subscriptions on the host to keep physics authoritative

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922eec93a4c832fb2cb67f89389d2ef)