### PR TITLE
Wire lobby start flow and enforce turn ownership

### DIFF
--- a/Puckslide/Assets/Scripts/Commands/LocalInputRouter.cs
+++ b/Puckslide/Assets/Scripts/Commands/LocalInputRouter.cs
@@ -16,6 +16,7 @@ public class LocalInputRouter : MonoBehaviour
     private PlayerCommandTarget m_ActiveTarget = PlayerCommandTarget.Board;
     private int m_ActiveInstanceId = -1;
     private bool m_InputLocked;
+    private bool m_IsWhiteTurn = true;
 
     private void Awake()
     {
@@ -205,11 +206,13 @@ public class LocalInputRouter : MonoBehaviour
 
     private void OnTurnChanged(TurnChangeMessage message)
     {
-        m_InputLocked = message.IsWhiteTurn != LobbyState.LocalIsWhitePlayer;
+        m_IsWhiteTurn = message.IsWhiteTurn;
+        m_InputLocked = m_IsWhiteTurn != LobbyState.LocalIsWhitePlayer;
     }
 
     private void OnLobbySnapshot(NetworkLobbySnapshot _)
     {
-        m_InputLocked = PuckController.IsWhiteTurn != LobbyState.LocalIsWhitePlayer;
+        m_IsWhiteTurn = PuckController.IsWhiteTurn;
+        m_InputLocked = m_IsWhiteTurn != LobbyState.LocalIsWhitePlayer;
     }
 }

--- a/Puckslide/Assets/Scripts/Core/GameBootstrapper.cs
+++ b/Puckslide/Assets/Scripts/Core/GameBootstrapper.cs
@@ -1,0 +1,59 @@
+using Puckslide.Networking;
+using UnityEngine;
+
+public class GameBootstrapper : MonoBehaviour
+{
+    [Header("UI Root References")]
+    [SerializeField] private GameObject m_LobbyUIRoot;
+    [SerializeField] private GameObject m_GameUIRoot;
+
+    [Header("Optional")]
+    [SerializeField] private GameObject m_SetupPhaseRoot;
+    [SerializeField] private GameObject m_PuckPhaseRoot;
+
+    private void OnEnable()
+    {
+        NetworkEvents.OnGameStart.AddListener(OnGameStart);
+    }
+
+    private void OnDisable()
+    {
+        NetworkEvents.OnGameStart.RemoveListener(OnGameStart);
+    }
+
+    private void Start()
+    {
+        if (m_LobbyUIRoot != null)
+        {
+            m_LobbyUIRoot.SetActive(true);
+        }
+
+        if (m_GameUIRoot != null)
+        {
+            m_GameUIRoot.SetActive(false);
+        }
+    }
+
+    private void OnGameStart(GameStartMessage _)
+    {
+        if (m_LobbyUIRoot != null)
+        {
+            m_LobbyUIRoot.SetActive(false);
+        }
+
+        if (m_GameUIRoot != null)
+        {
+            m_GameUIRoot.SetActive(true);
+        }
+
+        if (m_SetupPhaseRoot != null)
+        {
+            m_SetupPhaseRoot.SetActive(true);
+        }
+
+        if (m_PuckPhaseRoot != null)
+        {
+            m_PuckPhaseRoot.SetActive(false);
+        }
+    }
+}

--- a/Puckslide/Assets/Scripts/Networking/LobbyUIController.cs
+++ b/Puckslide/Assets/Scripts/Networking/LobbyUIController.cs
@@ -1,0 +1,72 @@
+using Puckslide.Networking;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class LobbyUIController : MonoBehaviour
+{
+    [SerializeField] private TMP_Text m_RoleLabel;
+    [SerializeField] private TMP_Text m_ColorLabel;
+    [SerializeField] private Button m_StartMatchButton;
+    [SerializeField] private Toggle m_HostIsWhiteToggle;
+    [SerializeField] private CanvasGroup m_HostOnlyControls;
+
+    private void OnEnable()
+    {
+        NetworkEvents.OnLobbySnapshot.AddListener(OnLobbySnapshotReceived);
+    }
+
+    private void OnDisable()
+    {
+        NetworkEvents.OnLobbySnapshot.RemoveListener(OnLobbySnapshotReceived);
+    }
+
+    private void Start()
+    {
+        if (m_StartMatchButton != null)
+        {
+            m_StartMatchButton.onClick.AddListener(OnStartMatchClicked);
+        }
+    }
+
+    private void OnLobbySnapshotReceived(NetworkLobbySnapshot snapshot)
+    {
+        if (m_RoleLabel != null)
+        {
+            m_RoleLabel.text = LobbyState.LocalIsHost ? "Host" : "Guest";
+        }
+
+        if (m_ColorLabel != null)
+        {
+            m_ColorLabel.text = LobbyState.LocalIsWhitePlayer ? "White" : "Black";
+        }
+
+        bool isHost = LobbyState.LocalIsHost;
+
+        if (m_StartMatchButton != null)
+        {
+            m_StartMatchButton.interactable = isHost;
+            m_StartMatchButton.gameObject.SetActive(isHost);
+        }
+
+        if (m_HostIsWhiteToggle != null)
+        {
+            m_HostIsWhiteToggle.interactable = isHost;
+        }
+
+        if (m_HostOnlyControls != null)
+        {
+            m_HostOnlyControls.interactable = isHost;
+            m_HostOnlyControls.alpha = isHost ? 1f : 0.5f;
+            m_HostOnlyControls.blocksRaycasts = isHost;
+        }
+    }
+
+    private void OnStartMatchClicked()
+    {
+        if (NetworkSessionManager.Instance != null)
+        {
+            NetworkSessionManager.Instance.StartMatchAsHost();
+        }
+    }
+}

--- a/Puckslide/Assets/Scripts/Networking/MirrorMessages.cs
+++ b/Puckslide/Assets/Scripts/Networking/MirrorMessages.cs
@@ -9,6 +9,11 @@ namespace Puckslide.Networking
         public NetworkLobbySnapshot Snapshot;
     }
 
+    public struct MirrorGameStartMessage : NetworkMessage
+    {
+        public GameStartMessage Message;
+    }
+
     public struct MirrorPuckSnapshotMessage : NetworkMessage
     {
         public PuckStateSnapshotMessage Snapshot;

--- a/Puckslide/Assets/Scripts/Networking/MirrorNetworkBridge.cs
+++ b/Puckslide/Assets/Scripts/Networking/MirrorNetworkBridge.cs
@@ -66,6 +66,7 @@ namespace Puckslide.Networking
         private void RegisterClientHandlers()
         {
             NetworkClient.RegisterHandler<MirrorLobbySnapshotMessage>(OnMirrorLobbySnapshotReceived);
+            NetworkClient.RegisterHandler<MirrorGameStartMessage>(OnMirrorGameStartReceived);
             NetworkClient.RegisterHandler<MirrorPuckSnapshotMessage>(OnMirrorPuckSnapshotReceived);
             NetworkClient.RegisterHandler<MirrorPuckSpawnMessage>(OnMirrorPuckSpawnReceived);
             NetworkClient.RegisterHandler<MirrorPuckDespawnMessage>(OnMirrorPuckDespawnReceived);
@@ -76,6 +77,7 @@ namespace Puckslide.Networking
         private void UnregisterClientHandlers()
         {
             NetworkClient.UnregisterHandler<MirrorLobbySnapshotMessage>();
+            NetworkClient.UnregisterHandler<MirrorGameStartMessage>();
             NetworkClient.UnregisterHandler<MirrorPuckSnapshotMessage>();
             NetworkClient.UnregisterHandler<MirrorPuckSpawnMessage>();
             NetworkClient.UnregisterHandler<MirrorPuckDespawnMessage>();
@@ -86,6 +88,7 @@ namespace Puckslide.Networking
         private void RegisterServerHandlers()
         {
             NetworkServer.RegisterHandler<MirrorLobbySnapshotMessage>(OnMirrorLobbySnapshotReceived);
+            NetworkServer.RegisterHandler<MirrorGameStartMessage>(OnMirrorGameStartReceived);
             NetworkServer.RegisterHandler<MirrorPuckSnapshotMessage>(OnMirrorPuckSnapshotReceived);
             NetworkServer.RegisterHandler<MirrorPuckSpawnMessage>(OnMirrorPuckSpawnReceived);
             NetworkServer.RegisterHandler<MirrorPuckDespawnMessage>(OnMirrorPuckDespawnReceived);
@@ -97,6 +100,7 @@ namespace Puckslide.Networking
         private void UnregisterServerHandlers()
         {
             NetworkServer.UnregisterHandler<MirrorLobbySnapshotMessage>();
+            NetworkServer.UnregisterHandler<MirrorGameStartMessage>();
             NetworkServer.UnregisterHandler<MirrorPuckSnapshotMessage>();
             NetworkServer.UnregisterHandler<MirrorPuckSpawnMessage>();
             NetworkServer.UnregisterHandler<MirrorPuckDespawnMessage>();
@@ -108,6 +112,7 @@ namespace Puckslide.Networking
         private void SubscribeToNetworkEvents()
         {
             NetworkEvents.OnLobbySnapshot.AddListener(OnLobbySnapshotBroadcasted);
+            NetworkEvents.OnGameStart.AddListener(OnLocalGameStart);
             NetworkEvents.OnPuckSnapshot.AddListener(OnPuckSnapshotBroadcasted);
             NetworkEvents.OnNetworkPuckSpawned.AddListener(OnPuckSpawnBroadcasted);
             NetworkEvents.OnNetworkPuckDespawned.AddListener(OnPuckDespawnBroadcasted);
@@ -119,6 +124,7 @@ namespace Puckslide.Networking
         private void UnsubscribeFromNetworkEvents()
         {
             NetworkEvents.OnLobbySnapshot.RemoveListener(OnLobbySnapshotBroadcasted);
+            NetworkEvents.OnGameStart.RemoveListener(OnLocalGameStart);
             NetworkEvents.OnPuckSnapshot.RemoveListener(OnPuckSnapshotBroadcasted);
             NetworkEvents.OnNetworkPuckSpawned.RemoveListener(OnPuckSpawnBroadcasted);
             NetworkEvents.OnNetworkPuckDespawned.RemoveListener(OnPuckDespawnBroadcasted);
@@ -197,6 +203,26 @@ namespace Puckslide.Networking
             NetworkServer.SendToAll(new MirrorTurnDeterminismMessage { Turn = turn });
         }
 
+        private void OnLocalGameStart(GameStartMessage message)
+        {
+            if (!IsHost)
+            {
+                return;
+            }
+
+            if (!NetworkServer.active)
+            {
+                return;
+            }
+
+            MirrorGameStartMessage mirrorMsg = new MirrorGameStartMessage
+            {
+                Message = message
+            };
+
+            NetworkServer.SendToAll(mirrorMsg);
+        }
+
         private void OnPlayerCommandSubmitted(PlayerCommandMessage command)
         {
             if (command == null || IsHost)
@@ -210,6 +236,22 @@ namespace Puckslide.Networking
         private void OnMirrorLobbySnapshotReceived(NetworkConnection conn, MirrorLobbySnapshotMessage msg)
         {
             LobbyState.ApplySnapshot(msg.Snapshot);
+        }
+
+        private void OnMirrorGameStartReceived(NetworkConnection conn, MirrorGameStartMessage msg)
+        {
+            GameStartMessage message = msg.Message;
+
+            NetworkSessionManager manager = NetworkSessionManager.Instance;
+            if (manager != null && !string.IsNullOrEmpty(manager.LobbyId))
+            {
+                if (message.LobbyId != manager.LobbyId)
+                {
+                    return;
+                }
+            }
+
+            NetworkEvents.OnGameStart.Invoke(message);
         }
 
         private void OnMirrorPuckSnapshotReceived(NetworkConnection conn, MirrorPuckSnapshotMessage msg)

--- a/Puckslide/Assets/Scripts/Networking/NetworkEvents.cs
+++ b/Puckslide/Assets/Scripts/Networking/NetworkEvents.cs
@@ -19,6 +19,7 @@ namespace Puckslide.Networking
         });
         public static readonly NetworkEvt<bool> OnBoardFlipState = new NetworkEvt<bool>();
         public static readonly NetworkEvt<NetworkLobbySnapshot> OnLobbySnapshot = new NetworkEvt<NetworkLobbySnapshot>();
+        public static readonly NetworkEvt<GameStartMessage> OnGameStart = new NetworkEvt<GameStartMessage>();
         public static readonly NetworkEvt<PuckSpawnMessage> OnNetworkPuckSpawned = new NetworkEvt<PuckSpawnMessage>();
         public static readonly NetworkEvt<PuckDespawnMessage> OnNetworkPuckDespawned = new NetworkEvt<PuckDespawnMessage>();
         public static readonly NetworkEvt<ShotLaunchMessage> OnShotLaunched = new NetworkEvt<ShotLaunchMessage>();

--- a/Puckslide/Assets/Scripts/Networking/NetworkMessages.cs
+++ b/Puckslide/Assets/Scripts/Networking/NetworkMessages.cs
@@ -9,8 +9,15 @@ namespace Puckslide.Networking
         public string LobbyId;
         public LobbySnapshot Snapshot;
         public bool HostIsAuthoritative;
-        public ulong HostPeerId;
+        public string HostPeerId;
         public uint SnapshotVersion;
+        public double ServerTime;
+    }
+
+    [Serializable]
+    public struct GameStartMessage
+    {
+        public string LobbyId;
         public double ServerTime;
     }
 

--- a/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
+++ b/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
@@ -44,7 +44,7 @@ namespace Puckslide.Networking
         private Coroutine m_SnapshotRoutine;
         private Coroutine m_PuckSnapshotRoutine;
         private uint m_SnapshotVersion;
-        private ulong m_LocalPeerId;
+        private string m_LocalPeerId;
         private bool m_IsHost;
         private string m_CurrentLobbyId;
         private LobbySnapshot m_PersistedLobbySnapshot;
@@ -66,7 +66,7 @@ namespace Puckslide.Networking
 
             s_Instance = this;
             m_CurrentLobbyId = string.IsNullOrEmpty(m_DefaultLobbyId) ? Guid.NewGuid().ToString("N") : m_DefaultLobbyId;
-            m_LocalPeerId = (ulong)UnityEngine.Random.Range(int.MinValue, int.MaxValue);
+            m_LocalPeerId = Guid.NewGuid().ToString("N");
             LobbyState.SetLocalPeerId(m_LocalPeerId);
 
             m_Dispatcher = PlayerCommandDispatcher.Instance ?? FindObjectOfType<PlayerCommandDispatcher>();
@@ -155,7 +155,7 @@ namespace Puckslide.Networking
 #endif
         }
 
-        public void PromoteNewHost(ulong hostPeerId)
+        public void PromoteNewHost(string hostPeerId)
         {
             bool localIsNewHost = hostPeerId == m_LocalPeerId;
             m_IsHost = localIsNewHost;
@@ -171,6 +171,23 @@ namespace Puckslide.Networking
                 StopSnapshotLoop();
                 StopPuckSnapshotLoop();
             }
+        }
+
+        public void StartMatchAsHost()
+        {
+            if (!m_IsHost)
+            {
+                Debug.LogWarning("Only host can start the match.");
+                return;
+            }
+
+            GameStartMessage message = new GameStartMessage
+            {
+                LobbyId = m_CurrentLobbyId,
+                ServerTime = Time.unscaledTimeAsDouble
+            };
+
+            NetworkEvents.OnGameStart.Invoke(message);
         }
 
         public void PublishLobbySnapshot(string reason)

--- a/Puckslide/Assets/Scripts/State/LobbyState.cs
+++ b/Puckslide/Assets/Scripts/State/LobbyState.cs
@@ -41,31 +41,19 @@ public static class LobbyState
     private static NetworkLobbySnapshot s_LatestSnapshot;
 
     public static bool LocalIsHost { get; private set; } = true;
-    public static ulong LocalPeerId { get; private set; }
+    public static string LocalPeerId { get; private set; }
+    public static bool LocalIsWhitePlayer { get; private set; } = true;
+    public static NetworkLobbySnapshot LatestSnapshot => s_LatestSnapshot;
     public static NetworkLobbySnapshot LatestNetworkSnapshot => s_LatestSnapshot;
     public static LobbySnapshot LatestLobbySnapshot => s_LatestSnapshot?.Snapshot;
     public static uint LatestSnapshotVersion => s_LatestSnapshot?.SnapshotVersion ?? 0u;
-
-    public static bool LocalIsWhitePlayer
-    {
-        get
-        {
-            LobbySnapshot snapshot = s_LatestSnapshot?.Snapshot;
-            if (snapshot == null)
-            {
-                return true;
-            }
-
-            return LocalIsHost ? snapshot.HostIsWhite : !snapshot.HostIsWhite;
-        }
-    }
 
     public static void SetLocalHost(bool isHost)
     {
         LocalIsHost = isHost;
     }
 
-    public static void SetLocalPeerId(ulong peerId)
+    public static void SetLocalPeerId(string peerId)
     {
         LocalPeerId = peerId;
     }
@@ -94,6 +82,17 @@ public static class LobbyState
 
         s_LatestSnapshot = snapshot;
         LocalIsHost = snapshot.HostPeerId == LocalPeerId && snapshot.HostIsAuthoritative;
+
+        bool hostIsWhite = snapshot.Snapshot.HostIsWhite;
+        if (LocalIsHost)
+        {
+            LocalIsWhitePlayer = hostIsWhite;
+        }
+        else
+        {
+            LocalIsWhitePlayer = !hostIsWhite;
+        }
+
         NetworkEvents.OnLobbySnapshot.Invoke(snapshot);
     }
 }


### PR DESCRIPTION
## Summary
- standardize lobby role/color tracking and snapshot handling
- update lobby UI and networking bridge to broadcast and react to game start events
- gate local input and add a bootstrapper to transition from lobby to gameplay

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ef910b50832f8bb0ce5aae585049)