### PR TITLE
Improve network quickplay and disconnect handling

### DIFF
--- a/Puckslide/Assets/Scripts/Networking/NetworkDisconnectHandler.cs
+++ b/Puckslide/Assets/Scripts/Networking/NetworkDisconnectHandler.cs
@@ -1,0 +1,74 @@
+using UnityEngine;
+
+#if MIRROR
+using Mirror;
+#endif
+
+namespace Puckslide.Networking
+{
+    [AddComponentMenu("Networking/Network Disconnect Handler")]
+    public class NetworkDisconnectHandler : MonoBehaviour
+    {
+        [SerializeField]
+        private NetworkSessionManager m_SessionManager;
+#if MIRROR
+        [SerializeField]
+        private NetworkManager m_NetworkManager;
+#endif
+
+        private void Awake()
+        {
+            if (m_SessionManager == null)
+            {
+                m_SessionManager = NetworkSessionManager.Instance ?? FindObjectOfType<NetworkSessionManager>();
+            }
+#if MIRROR
+            if (m_NetworkManager == null)
+            {
+                m_NetworkManager = FindObjectOfType<NetworkManager>();
+            }
+#endif
+        }
+
+        private void OnEnable()
+        {
+            NetworkEvents.OnDisconnected.AddListener(OnDisconnected);
+        }
+
+        private void OnDisable()
+        {
+            NetworkEvents.OnDisconnected.RemoveListener(OnDisconnected);
+        }
+
+        private void OnDisconnected(NetworkDisconnectReason reason)
+        {
+#if MIRROR
+            if (m_NetworkManager != null)
+            {
+                if (m_NetworkManager.mode == NetworkManagerMode.Host)
+                {
+                    m_NetworkManager.StopHost();
+                }
+                else if (m_NetworkManager.mode == NetworkManagerMode.ServerOnly)
+                {
+                    m_NetworkManager.StopServer();
+                }
+                else if (m_NetworkManager.mode == NetworkManagerMode.ClientOnly)
+                {
+                    m_NetworkManager.StopClient();
+                }
+            }
+#endif
+
+            if (m_SessionManager == null)
+            {
+                m_SessionManager = NetworkSessionManager.Instance ?? FindObjectOfType<NetworkSessionManager>();
+            }
+
+            if (m_SessionManager != null)
+            {
+                m_SessionManager.HandleDisconnect(reason);
+            }
+        }
+    }
+}

--- a/Puckslide/Assets/Scripts/Networking/NetworkEvents.cs
+++ b/Puckslide/Assets/Scripts/Networking/NetworkEvents.cs
@@ -6,6 +6,7 @@ namespace Puckslide.Networking
 {
     public static class NetworkEvents
     {
+        public static readonly NetworkEvt<NetworkDisconnectReason> OnDisconnected = new NetworkEvt<NetworkDisconnectReason>();
         public static readonly NetworkEvt<bool> OnDeletePucks = new NetworkEvt<bool>();
         public static readonly NetworkEvt<PieceSetupMessage> OnPieceSetupData = new NetworkEvt<PieceSetupMessage>();
         public static readonly NetworkEvt<Dictionary<Vector2Int, ChessPiece>> OnBoardLayout = new NetworkEvt<Dictionary<Vector2Int, ChessPiece>>();
@@ -26,6 +27,15 @@ namespace Puckslide.Networking
         public static readonly NetworkEvt<PlayerCommandMessage> OnPlayerCommandSubmitted = new NetworkEvt<PlayerCommandMessage>();
         public static readonly NetworkEvt<PuckStateSnapshotMessage> OnPuckSnapshot = new NetworkEvt<PuckStateSnapshotMessage>();
         public static readonly NetworkEvt<TurnDeterminismMessage> OnTurnDeterminism = new NetworkEvt<TurnDeterminismMessage>();
+    }
+
+    public enum NetworkDisconnectReason
+    {
+        Unknown,
+        RemoteClosed,
+        Timeout,
+        Kicked,
+        TransportError
     }
 
     public class NetworkEvt<T>

--- a/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
+++ b/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
@@ -30,6 +30,8 @@ namespace Puckslide.Networking
         private float m_AcceptablePacketLossPercent = 1.5f;
         [SerializeField]
         private int m_MaxTurnHistory = 5;
+        [SerializeField]
+        private float m_ConnectionTimeoutSeconds = 10f;
 
 #if MIRROR
         [SerializeField]
@@ -51,6 +53,8 @@ namespace Puckslide.Networking
         private readonly List<TurnDeterminismMessage> m_TurnHistory = new List<TurnDeterminismMessage>();
         private PlayerCommandDispatcher m_Dispatcher;
         private GridManager m_GridManager;
+        private double m_LastSnapshotReceivedTime;
+        private bool m_ConnectionTimedOut;
 
         public static NetworkSessionManager Instance => s_Instance;
         public bool IsHost => m_IsHost;
@@ -83,6 +87,7 @@ namespace Puckslide.Networking
 
             NetworkEvents.OnPlayerCommandSubmitted.AddListener(OnPlayerCommandSubmitted);
             NetworkEvents.OnTurnChanged.AddListener(OnTurnChangedForDeterminism, true);
+            NetworkEvents.OnPuckSnapshot.AddListener(OnAnyPuckSnapshot);
         }
 
         private bool ShouldAutoStartHost()
@@ -113,12 +118,34 @@ namespace Puckslide.Networking
 
             NetworkEvents.OnPlayerCommandSubmitted.RemoveListener(OnPlayerCommandSubmitted);
             NetworkEvents.OnTurnChanged.RemoveListener(OnTurnChangedForDeterminism);
+            NetworkEvents.OnPuckSnapshot.RemoveListener(OnAnyPuckSnapshot);
+        }
+
+        private void Update()
+        {
+            if (m_ConnectionTimedOut)
+            {
+                return;
+            }
+
+            if (m_ConnectionTimeoutSeconds > 0f && m_LastSnapshotReceivedTime > 0d)
+            {
+                double now = Time.unscaledTimeAsDouble;
+                if (now - m_LastSnapshotReceivedTime > m_ConnectionTimeoutSeconds)
+                {
+                    m_ConnectionTimedOut = true;
+                    Debug.LogWarning("[Networking] Connection timed out (no snapshots received).");
+                    NetworkEvents.OnDisconnected.Invoke(NetworkDisconnectReason.Timeout);
+                }
+            }
         }
 
         public void CreateLobby(string lobbyId = null)
         {
             m_IsHost = true;
             m_CurrentLobbyId = string.IsNullOrEmpty(lobbyId) ? m_CurrentLobbyId : lobbyId;
+            m_LastSnapshotReceivedTime = Time.unscaledTimeAsDouble;
+            m_ConnectionTimedOut = false;
             LobbyState.SetLocalHost(true);
             m_SnapshotVersion = 0;
             m_PersistedLobbySnapshot = LobbyState.LatestLobbySnapshot ?? new LobbySnapshot
@@ -142,6 +169,8 @@ namespace Puckslide.Networking
         {
             m_IsHost = false;
             m_CurrentLobbyId = lobbyId;
+            m_LastSnapshotReceivedTime = Time.unscaledTimeAsDouble;
+            m_ConnectionTimedOut = false;
             LobbyState.SetLocalHost(false);
             StopSnapshotLoop();
             StopPuckSnapshotLoop();
@@ -513,6 +542,21 @@ namespace Puckslide.Networking
             }
 
             return puck.IsWhitePiece == PuckController.IsWhiteTurn;
+        }
+
+        public void HandleDisconnect(NetworkDisconnectReason reason)
+        {
+            StopSnapshotLoop();
+            StopPuckSnapshotLoop();
+            m_ConnectionTimedOut = false;
+            m_LastSnapshotReceivedTime = 0d;
+            Debug.Log($"[Networking] Handling disconnect ({reason}).");
+        }
+
+        private void OnAnyPuckSnapshot(PuckStateSnapshotMessage snapshot)
+        {
+            m_LastSnapshotReceivedTime = Time.unscaledTimeAsDouble;
+            m_ConnectionTimedOut = false;
         }
 
         private void PublishDeterminismSnapshot(uint turnNumber)

--- a/Puckslide/Assets/Scripts/Networking/PuckslideNetworkManager.cs
+++ b/Puckslide/Assets/Scripts/Networking/PuckslideNetworkManager.cs
@@ -1,0 +1,34 @@
+#if MIRROR
+using Mirror;
+using UnityEngine;
+
+namespace Puckslide.Networking
+{
+    [AddComponentMenu("Networking/Puckslide Network Manager")]
+    public class PuckslideNetworkManager : NetworkManager
+    {
+        public override void OnClientDisconnect()
+        {
+            base.OnClientDisconnect();
+
+            Debug.Log("[Networking] Client disconnected from server.");
+            NetworkEvents.OnDisconnected.Invoke(NetworkDisconnectReason.RemoteClosed);
+        }
+
+        public override void OnServerDisconnect(NetworkConnectionToClient conn)
+        {
+            base.OnServerDisconnect(conn);
+
+            Debug.Log($"[Networking] Client {conn.connectionId} disconnected from host.");
+            NetworkEvents.OnDisconnected.Invoke(NetworkDisconnectReason.RemoteClosed);
+        }
+
+        public override void OnClientError(TransportError error, string message)
+        {
+            base.OnClientError(error, message);
+            Debug.LogWarning($"[Networking] Client transport error: {error} {message}");
+            NetworkEvents.OnDisconnected.Invoke(NetworkDisconnectReason.TransportError);
+        }
+    }
+}
+#endif

--- a/Puckslide/Assets/Scripts/Networking/SteamworksBootstrap.cs
+++ b/Puckslide/Assets/Scripts/Networking/SteamworksBootstrap.cs
@@ -34,6 +34,20 @@ namespace Puckslide.Networking
         private bool m_DriveNetworkSession = true;
         [SerializeField]
         private NetworkSessionManager m_SessionManager;
+        [SerializeField]
+        private int m_MaxPlayers = 2;
+#if STEAMWORKSNET
+        [SerializeField]
+        private ELobbyType m_DefaultLobbyType = ELobbyType.k_ELobbyTypeFriendsOnly;
+#else
+        [SerializeField]
+        private int m_DefaultLobbyType = 0;
+#endif
+        [Header("Quickplay")]
+        [SerializeField]
+        private bool m_EnableQuickplay = true;
+        [SerializeField]
+        private int m_QuickplayMaxPlayers = 2;
 
         public bool Initialized { get; private set; }
         public bool LoggedOn { get; private set; }
@@ -66,6 +80,15 @@ namespace Puckslide.Networking
             if (m_InitializeOnAwake)
             {
                 Initialize();
+            }
+
+            if (m_DriveNetworkSession && m_SessionManager == null)
+            {
+                m_SessionManager = FindObjectOfType<NetworkSessionManager>();
+                if (m_SessionManager == null)
+                {
+                    Debug.LogWarning("[Steamworks] m_DriveNetworkSession is true, but no NetworkSessionManager was found in the scene.");
+                }
             }
         }
 
@@ -143,6 +166,56 @@ namespace Puckslide.Networking
 #else
             Debug.LogWarning("Steamworks.NET is not enabled; Steam features are disabled.");
 #endif
+        }
+
+        public void HostSteamLobby()
+        {
+            if (!Initialized)
+            {
+                Debug.LogWarning("[Steamworks] Cannot host lobby before initialization.");
+                return;
+            }
+
+            CreateLobby(m_MaxPlayers, m_DefaultLobbyType);
+        }
+
+        public void JoinSteamLobbyById(ulong lobbyId)
+        {
+            if (!Initialized)
+            {
+                Debug.LogWarning("[Steamworks] Cannot join lobby before initialization.");
+                return;
+            }
+
+            JoinLobby(lobbyId);
+        }
+
+        public void RequestQuickplayLobbies()
+        {
+            if (!Initialized)
+            {
+                Debug.LogWarning("[Steamworks] Cannot request quickplay lobbies before initialization.");
+                return;
+            }
+
+            RequestLobbyList();
+        }
+
+        public void Quickplay()
+        {
+            if (!m_EnableQuickplay)
+            {
+                Debug.Log("[Steamworks] Quickplay is disabled.");
+                return;
+            }
+
+            if (!Initialized)
+            {
+                Debug.LogWarning("[Steamworks] Cannot quickplay before initialization.");
+                return;
+            }
+
+            RequestLobbyList();
         }
 
         private void WriteSteamAppId()
@@ -274,6 +347,11 @@ namespace Puckslide.Networking
             }
 
             OnLobbyListUpdated?.Invoke(summaries);
+
+            if (m_EnableQuickplay)
+            {
+                HandleQuickplayFromSummaries(summaries);
+            }
         }
 
         private void OnLobbyCreated(LobbyCreated_t result, bool ioFailure)
@@ -345,6 +423,33 @@ namespace Puckslide.Networking
             Debug.Log($"[Steamworks] Received lobby invite to {lobbyId} from {invite.m_ulSteamIDUser}.");
         }
 #endif
+
+        private void HandleQuickplayFromSummaries(IReadOnlyList<SteamLobbySummary> summaries)
+        {
+            SteamLobbySummary? best = null;
+            foreach (SteamLobbySummary summary in summaries)
+            {
+                if (summary.MemberCount >= summary.MaxMembers)
+                {
+                    continue;
+                }
+
+                if (best == null || summary.MemberCount > best.Value.MemberCount)
+                {
+                    best = summary;
+                }
+            }
+
+            if (best.HasValue)
+            {
+                Debug.Log($"[Steamworks] Quickplay joining lobby {best.Value.LobbyId} ({best.Value.MemberCount}/{best.Value.MaxMembers}).");
+                JoinLobby(best.Value.LobbyId);
+                return;
+            }
+
+            Debug.Log("[Steamworks] Quickplay creating a new lobby (no suitable existing lobbies).");
+            CreateLobby(m_QuickplayMaxPlayers, m_DefaultLobbyType);
+        }
     }
 
     public struct SteamLobbySummary

--- a/Puckslide/Assets/Scripts/UI/NetworkErrorHUD.cs
+++ b/Puckslide/Assets/Scripts/UI/NetworkErrorHUD.cs
@@ -1,0 +1,75 @@
+using Puckslide.Networking;
+using TMPro;
+using UnityEngine;
+
+public class NetworkErrorHUD : MonoBehaviour
+{
+    [SerializeField] private CanvasGroup m_Panel;
+    [SerializeField] private TMP_Text m_MessageLabel;
+    [SerializeField] private float m_AutoReturnDelay = 3f;
+    [SerializeField] private GameObject m_LobbyUIRoot;
+    [SerializeField] private GameObject m_GameUIRoot;
+
+    private void OnEnable()
+    {
+        NetworkEvents.OnDisconnected.AddListener(OnDisconnected);
+    }
+
+    private void OnDisable()
+    {
+        NetworkEvents.OnDisconnected.RemoveListener(OnDisconnected);
+    }
+
+    private void Start()
+    {
+        if (m_Panel != null)
+        {
+            m_Panel.alpha = 0f;
+            m_Panel.interactable = false;
+            m_Panel.blocksRaycasts = false;
+        }
+    }
+
+    private void OnDisconnected(NetworkDisconnectReason reason)
+    {
+        if (m_Panel != null)
+        {
+            m_Panel.alpha = 1f;
+            m_Panel.interactable = true;
+            m_Panel.blocksRaycasts = true;
+        }
+
+        if (m_MessageLabel != null)
+        {
+            m_MessageLabel.text = reason switch
+            {
+                NetworkDisconnectReason.Timeout => "Connection lost (timeout).",
+                NetworkDisconnectReason.RemoteClosed => "Connection closed.",
+                NetworkDisconnectReason.TransportError => "Network error occurred.",
+                _ => "Disconnected from match."
+            };
+        }
+
+        Invoke(nameof(ReturnToLobby), m_AutoReturnDelay);
+    }
+
+    private void ReturnToLobby()
+    {
+        if (m_LobbyUIRoot != null)
+        {
+            m_LobbyUIRoot.SetActive(true);
+        }
+
+        if (m_GameUIRoot != null)
+        {
+            m_GameUIRoot.SetActive(false);
+        }
+
+        if (m_Panel != null)
+        {
+            m_Panel.alpha = 0f;
+            m_Panel.interactable = false;
+            m_Panel.blocksRaycasts = false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add quickplay helpers and UI-friendly lobby entry points in SteamworksBootstrap
- add disconnect event handling, timeout detection, and Mirror-aware manager wrapper
- surface disconnect reasons in HUD and clean up sessions via new handlers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f0c2c9dc832f9f752069850b5caa)