### PR TITLE
Add network HUD, debug overlay, and build configuration toggles

### DIFF
--- a/Puckslide/Assets/Scripts/Config/BuildConfig.cs
+++ b/Puckslide/Assets/Scripts/Config/BuildConfig.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace Puckslide
+{
+    [CreateAssetMenu(fileName = "BuildConfig", menuName = "Puckslide/Build Config")]
+    public class BuildConfig : ScriptableObject
+    {
+        public bool EnableSteam = true;
+        public bool EnableMirror = true;
+        public bool EnableDebugOverlayInRelease = true;
+    }
+}

--- a/Puckslide/Assets/Scripts/Debug/NetworkDebugOverlay.cs
+++ b/Puckslide/Assets/Scripts/Debug/NetworkDebugOverlay.cs
@@ -1,0 +1,79 @@
+using UnityEngine;
+using TMPro;
+using Puckslide;
+using Puckslide.Networking;
+
+public class NetworkDebugOverlay : MonoBehaviour
+{
+    [SerializeField] private CanvasGroup m_DebugPanel;
+    [SerializeField] private TMP_Text m_Text;
+    [SerializeField] private KeyCode m_ToggleKey = KeyCode.F1;
+
+    [SerializeField] private bool m_StartVisibleInEditor = true;
+
+    private bool m_Visible;
+    private bool m_OverlayAllowed = true;
+
+    private void Start()
+    {
+#if UNITY_EDITOR
+        m_Visible = m_StartVisibleInEditor;
+#else
+        BuildConfig config = Resources.Load<BuildConfig>("BuildConfig");
+        m_OverlayAllowed = config == null || config.EnableDebugOverlayInRelease;
+        m_Visible = false;
+#endif
+        ApplyVisibility();
+    }
+
+    private void Update()
+    {
+        if (!m_OverlayAllowed)
+        {
+            return;
+        }
+
+        if (Input.GetKeyDown(m_ToggleKey))
+        {
+            m_Visible = !m_Visible;
+            ApplyVisibility();
+        }
+
+        if (!m_Visible || m_Text == null)
+            return;
+
+        var nsm = NetworkSessionManager.Instance;
+        if (nsm == null)
+        {
+            m_Text.text = "No NetworkSessionManager.";
+            return;
+        }
+
+        string phaseLabel = Phase2Manager.IsPhase2Active ? "Phase 2" : "Phase 1";
+
+        m_Text.text =
+            $"LobbyId: {nsm.LobbyId}\n" +
+            $"IsHost: {nsm.IsHost}\n" +
+            $"Phase: {phaseLabel}\n" +
+            $"Turn: {PuckController.TurnNumber}\n" +
+            $"LocalIsWhite: {LobbyState.LocalIsWhitePlayer}\n" +
+            $"WhiteTurn: {PuckController.IsWhiteTurn}\n" +
+            $"OfflineMode: {nsm.OfflineMode}";
+
+        NetworkDiagnostics diagnostics = nsm.Diagnostics;
+        if (diagnostics != null)
+        {
+            m_Text.text += $"\nPing: {diagnostics.LatencyEstimateMs:0} ms";
+            m_Text.text += $"\nLoss: {diagnostics.PacketLossEstimatePercent:0.0}%";
+        }
+    }
+
+    private void ApplyVisibility()
+    {
+        if (m_DebugPanel == null) return;
+
+        m_DebugPanel.alpha = m_Visible ? 1f : 0f;
+        m_DebugPanel.interactable = m_Visible;
+        m_DebugPanel.blocksRaycasts = m_Visible;
+    }
+}

--- a/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
+++ b/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Puckslide;
 
 #if MIRROR
 using Mirror;
@@ -32,6 +33,12 @@ namespace Puckslide.Networking
         private int m_MaxTurnHistory = 5;
         [SerializeField]
         private float m_ConnectionTimeoutSeconds = 10f;
+        [SerializeField]
+        private bool m_OfflineMode;
+        [SerializeField]
+        private BuildConfig m_BuildConfig;
+        [SerializeField]
+        private NetworkDiagnostics m_Diagnostics;
 
 #if MIRROR
         [SerializeField]
@@ -59,6 +66,8 @@ namespace Puckslide.Networking
         public static NetworkSessionManager Instance => s_Instance;
         public bool IsHost => m_IsHost;
         public string LobbyId => m_CurrentLobbyId;
+        public bool OfflineMode => m_OfflineMode;
+        public NetworkDiagnostics Diagnostics => m_Diagnostics;
 
         private void Awake()
         {
@@ -99,6 +108,11 @@ namespace Puckslide.Networking
             }
 #endif
 
+            if (m_OfflineMode)
+            {
+                return false;
+            }
+
             return m_StartAsHost;
         }
 
@@ -123,6 +137,11 @@ namespace Puckslide.Networking
 
         private void Update()
         {
+            if (m_OfflineMode)
+            {
+                return;
+            }
+
             if (m_ConnectionTimedOut)
             {
                 return;
@@ -142,6 +161,14 @@ namespace Puckslide.Networking
 
         public void CreateLobby(string lobbyId = null)
         {
+            if (m_OfflineMode)
+            {
+                m_IsHost = true;
+                LobbyState.SetLocalHost(true);
+                m_CurrentLobbyId = string.IsNullOrEmpty(lobbyId) ? m_CurrentLobbyId : lobbyId;
+                return;
+            }
+
             m_IsHost = true;
             m_CurrentLobbyId = string.IsNullOrEmpty(lobbyId) ? m_CurrentLobbyId : lobbyId;
             m_LastSnapshotReceivedTime = Time.unscaledTimeAsDouble;
@@ -158,7 +185,7 @@ namespace Puckslide.Networking
             PublishLobbySnapshot("host-created");
 
 #if MIRROR
-            if (m_NetworkManager != null)
+            if (m_NetworkManager != null && IsMirrorEnabled())
             {
                 m_NetworkManager.StartHost();
             }
@@ -167,6 +194,12 @@ namespace Puckslide.Networking
 
         public void JoinLobby(string lobbyId)
         {
+            if (m_OfflineMode)
+            {
+                Debug.Log("[Networking] Offline mode is enabled; ignoring JoinLobby call.");
+                return;
+            }
+
             m_IsHost = false;
             m_CurrentLobbyId = lobbyId;
             m_LastSnapshotReceivedTime = Time.unscaledTimeAsDouble;
@@ -176,7 +209,7 @@ namespace Puckslide.Networking
             StopPuckSnapshotLoop();
 
 #if MIRROR
-            if (m_NetworkManager != null)
+            if (m_NetworkManager != null && IsMirrorEnabled())
             {
                 m_NetworkManager.networkAddress = lobbyId;
                 m_NetworkManager.StartClient();
@@ -376,6 +409,12 @@ namespace Puckslide.Networking
 
         public void SubmitPlayerCommand(PlayerCommand command)
         {
+            if (m_OfflineMode)
+            {
+                TryApplyCommandAsHost(command);
+                return;
+            }
+
             // Host: apply command directly into the simulation.
             if (m_IsHost)
             {
@@ -395,7 +434,7 @@ namespace Puckslide.Networking
 #if MIRROR
             // If we have a Mirror bridge and a live client connection,
             // send the command to the host over the network.
-            if (MirrorNetworkBridge.Instance != null)
+            if (MirrorNetworkBridge.Instance != null && IsMirrorEnabled())
             {
                 MirrorNetworkBridge.Instance.SendPlayerCommand(message);
                 return;
@@ -424,6 +463,11 @@ namespace Puckslide.Networking
 
         private void StartSnapshotLoop()
         {
+            if (m_OfflineMode)
+            {
+                return;
+            }
+
             StopSnapshotLoop();
             if (m_SnapshotIntervalSeconds > 0f)
             {
@@ -433,6 +477,11 @@ namespace Puckslide.Networking
 
         private void StartPuckSnapshotLoop()
         {
+            if (m_OfflineMode)
+            {
+                return;
+            }
+
             StopPuckSnapshotLoop();
             if (m_PuckSnapshotInterval > 0f)
             {
@@ -592,5 +641,41 @@ namespace Puckslide.Networking
                 PublishPuckSnapshot();
             }
         }
+
+        public void SetOfflineMode(bool offline)
+        {
+            m_OfflineMode = offline;
+            if (offline)
+            {
+                m_IsHost = true;
+                LobbyState.SetLocalHost(true);
+                StopSnapshotLoop();
+                StopPuckSnapshotLoop();
+            }
+        }
+
+        private bool IsMirrorEnabled()
+        {
+            BuildConfig config = ResolveBuildConfig();
+            return config == null || config.EnableMirror;
+        }
+
+        private BuildConfig ResolveBuildConfig()
+        {
+            if (m_BuildConfig != null)
+            {
+                return m_BuildConfig;
+            }
+
+            m_BuildConfig = Resources.Load<BuildConfig>("BuildConfig");
+            return m_BuildConfig;
+        }
+    }
+
+    [Serializable]
+    public class NetworkDiagnostics
+    {
+        public float LatencyEstimateMs;
+        public float PacketLossEstimatePercent;
     }
 }

--- a/Puckslide/Assets/Scripts/Networking/SteamworksBootstrap.cs
+++ b/Puckslide/Assets/Scripts/Networking/SteamworksBootstrap.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
+using Puckslide;
+using TMPro;
 
 #if STEAMWORKSNET
 using Steamworks;
@@ -43,6 +45,11 @@ namespace Puckslide.Networking
         [SerializeField]
         private int m_DefaultLobbyType = 0;
 #endif
+        [Header("Debug")]
+        [SerializeField]
+        private TMP_Text m_DebugStatusLabel;
+        [SerializeField]
+        private BuildConfig m_BuildConfig;
         [Header("Quickplay")]
         [SerializeField]
         private bool m_EnableQuickplay = true;
@@ -119,6 +126,13 @@ namespace Puckslide.Networking
 
         public void Initialize()
         {
+            if (!IsSteamEnabled())
+            {
+                Debug.Log("[Steamworks] Steam initialization disabled via BuildConfig.");
+                UpdateDebugStatusLabel("Steam: DISABLED (BuildConfig)");
+                return;
+            }
+
 #if STEAMWORKSNET
             if (Initialized)
             {
@@ -135,6 +149,7 @@ namespace Puckslide.Networking
             if (!Packsize.Test() || !DllCheck.Test())
             {
                 Debug.LogError("[Steamworks] Steamworks binaries appear to be the wrong version for this platform.");
+                UpdateDebugStatusLabel("Steam: FAILED (binary mismatch)");
                 return;
             }
 
@@ -142,6 +157,7 @@ namespace Puckslide.Networking
             if (!Initialized)
             {
                 Debug.LogError("[Steamworks] Steam API initialization failed.");
+                UpdateDebugStatusLabel("Steam: FAILED (running without Steam)");
                 return;
             }
 
@@ -163,8 +179,10 @@ namespace Puckslide.Networking
             }
 
             Debug.Log($"[Steamworks] Initialized. Logged in: {LoggedOn} as {PersonaName} ({SteamId}).");
+            UpdateDebugStatusLabel($"Steam: OK ({PersonaName})");
 #else
             Debug.LogWarning("Steamworks.NET is not enabled; Steam features are disabled.");
+            UpdateDebugStatusLabel("Steam: FAILED (Steamworks disabled)");
 #endif
         }
 
@@ -449,6 +467,31 @@ namespace Puckslide.Networking
 
             Debug.Log("[Steamworks] Quickplay creating a new lobby (no suitable existing lobbies).");
             CreateLobby(m_QuickplayMaxPlayers, m_DefaultLobbyType);
+        }
+
+        private bool IsSteamEnabled()
+        {
+            BuildConfig config = ResolveBuildConfig();
+            return config == null || config.EnableSteam;
+        }
+
+        private BuildConfig ResolveBuildConfig()
+        {
+            if (m_BuildConfig != null)
+            {
+                return m_BuildConfig;
+            }
+
+            m_BuildConfig = Resources.Load<BuildConfig>("BuildConfig");
+            return m_BuildConfig;
+        }
+
+        private void UpdateDebugStatusLabel(string text)
+        {
+            if (m_DebugStatusLabel != null)
+            {
+                m_DebugStatusLabel.text = text;
+            }
         }
     }
 

--- a/Puckslide/Assets/Scripts/UI/MainMenuController.cs
+++ b/Puckslide/Assets/Scripts/UI/MainMenuController.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Puckslide.Networking;
+
+public class MainMenuController : MonoBehaviour
+{
+    [SerializeField] private GameObject m_MainMenuRoot;
+    [SerializeField] private GameObject m_LobbyRoot;
+    [SerializeField] private GameObject m_LocalPlayRoot;
+
+    public void OnLocalPlayClicked()
+    {
+        if (m_MainMenuRoot != null) m_MainMenuRoot.SetActive(false);
+        if (m_LocalPlayRoot != null) m_LocalPlayRoot.SetActive(true);
+
+        var nsm = FindObjectOfType<NetworkSessionManager>();
+        if (nsm != null)
+        {
+            nsm.SetOfflineMode(true);
+        }
+
+        // You can either:
+        // - Stay in this scene and just disable networking
+        // - Or call SceneManager.LoadScene("GameSceneLocal");
+    }
+
+    public void OnOnlinePlayClicked()
+    {
+        if (m_MainMenuRoot != null) m_MainMenuRoot.SetActive(false);
+        if (m_LobbyRoot != null) m_LobbyRoot.SetActive(true);
+
+        // Optionally initialize Steam here:
+        if (SteamworksBootstrap.Instance != null && !SteamworksBootstrap.Instance.Initialized)
+        {
+            SteamworksBootstrap.Instance.Initialize();
+        }
+    }
+
+    public void OnQuitClicked()
+    {
+        Application.Quit();
+#if UNITY_EDITOR
+        UnityEditor.EditorApplication.isPlaying = false;
+#endif
+    }
+}

--- a/Puckslide/Assets/Scripts/UI/NetworkStatusHUD.cs
+++ b/Puckslide/Assets/Scripts/UI/NetworkStatusHUD.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+using TMPro;
+using Puckslide.Networking;
+
+public class NetworkStatusHUD : MonoBehaviour
+{
+    [SerializeField] private TMP_Text m_StatusLabel;
+    [SerializeField] private bool m_ShowDetails = true;
+
+    private void Update()
+    {
+        if (m_StatusLabel == null)
+        {
+            return;
+        }
+
+        NetworkSessionManager manager = NetworkSessionManager.Instance;
+        if (manager == null)
+        {
+            m_StatusLabel.text = "Offline";
+            return;
+        }
+
+        if (manager.OfflineMode)
+        {
+            m_StatusLabel.text = "Offline";
+            return;
+        }
+
+        m_StatusLabel.text = manager.IsHost ? "Hosting game" : "In game";
+
+        NetworkDiagnostics diagnostics = manager.Diagnostics;
+        if (m_ShowDetails && diagnostics != null)
+        {
+            m_StatusLabel.text += $"\nPing: {diagnostics.LatencyEstimateMs:0} ms  |  Loss: {diagnostics.PacketLossEstimatePercent:0.0}%";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a BuildConfig ScriptableObject to gate Steam, Mirror, and debug overlay behavior and plug it into Steamworks initialization and session management
- implement an in-game network status HUD plus a toggleable debug overlay for live lobby, turn, and diagnostics visibility
- create a main menu controller and offline network mode support for local play flows

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f5e9b36c832fa7204964d75468a7)