### PR TITLE
Harden network authority and lobby validation

### DIFF
--- a/Puckslide/Assets/Scripts/Commands/SimulationCommandProcessor.cs
+++ b/Puckslide/Assets/Scripts/Commands/SimulationCommandProcessor.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Puckslide.Networking;
 using UnityEngine;
 
 public class SimulationCommandProcessor : MonoBehaviour
@@ -31,6 +32,13 @@ public class SimulationCommandProcessor : MonoBehaviour
     {
         if (m_Dispatcher == null)
         {
+            return;
+        }
+
+        NetworkSessionManager manager = NetworkSessionManager.Instance;
+        if (manager != null && !manager.OfflineMode && !manager.IsHost)
+        {
+            // Non-host clients rely on snapshots from the host instead of running the simulation loop locally.
             return;
         }
 

--- a/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
+++ b/Puckslide/Assets/Scripts/Networking/NetworkSessionManager.cs
@@ -407,6 +407,7 @@ namespace Puckslide.Networking
             NetworkEvents.OnShotLaunched.Invoke(message);
         }
 
+        // Submit a player command according to session authority and transport availability.
         public void SubmitPlayerCommand(PlayerCommand command)
         {
             if (m_OfflineMode)
@@ -441,9 +442,8 @@ namespace Puckslide.Networking
             }
 #endif
 
-            // Fallback path (no Mirror / offline testing): behave as before,
-            // delivering the message directly into the host event handler.
-            NetworkEvents.OnPlayerCommandSubmitted.Invoke(message);
+            // No transport available: drop the command to preserve host authority.
+            Debug.LogWarning("Dropping player command — no active network connection and not in offline mode.");
         }
 
         public void ReceiveSnapshot(NetworkLobbySnapshot snapshot)
@@ -558,8 +558,9 @@ namespace Puckslide.Networking
 
         private void TryApplyCommandAsHost(PlayerCommand command)
         {
-            if (!m_IsHost && command.CommandType == PlayerCommandType.PointerUp)
+            if (!m_IsHost)
             {
+                Debug.LogWarning("Rejected command application — local peer is not the host.");
                 return;
             }
 
@@ -600,6 +601,29 @@ namespace Puckslide.Networking
             m_ConnectionTimedOut = false;
             m_LastSnapshotReceivedTime = 0d;
             Debug.Log($"[Networking] Handling disconnect ({reason}).");
+
+#if MIRROR
+            // Ensure Mirror connections are torn down when the session ends, even without a dedicated handler.
+            try
+            {
+                NetworkManager networkManager = m_NetworkManager != null ? m_NetworkManager : FindObjectOfType<NetworkManager>();
+                if (networkManager != null && networkManager.isNetworkActive)
+                {
+                    if (m_IsHost)
+                    {
+                        networkManager.StopHost();
+                    }
+                    else
+                    {
+                        networkManager.StopClient();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[Networking] Failed to shut down Mirror transport: {ex.Message}");
+            }
+#endif
         }
 
         private void OnAnyPuckSnapshot(PuckStateSnapshotMessage snapshot)

--- a/Puckslide/Assets/Scripts/Networking/PuckStateReplicator.cs
+++ b/Puckslide/Assets/Scripts/Networking/PuckStateReplicator.cs
@@ -22,12 +22,14 @@ namespace Puckslide.Networking
 
             NetworkEvents.OnPuckSnapshot.AddListener(OnSnapshot);
             NetworkEvents.OnNetworkPuckSpawned.AddListener(OnSpawned);
+            NetworkEvents.OnNetworkPuckDespawned.AddListener(OnDespawned);
         }
 
         private void OnDisable()
         {
             NetworkEvents.OnPuckSnapshot.RemoveListener(OnSnapshot);
             NetworkEvents.OnNetworkPuckSpawned.RemoveListener(OnSpawned);
+            NetworkEvents.OnNetworkPuckDespawned.RemoveListener(OnDespawned);
             m_TargetStates.Clear();
         }
 
@@ -72,6 +74,13 @@ namespace Puckslide.Networking
                 return;
             }
 
+            string lobbyId = manager != null ? manager.LobbyId : null;
+            if (!string.IsNullOrEmpty(lobbyId) && message.LobbyId != lobbyId)
+            {
+                // Ignore snapshots from other lobbies or stale sessions.
+                return;
+            }
+
             m_TargetStates.Clear();
             foreach (PuckState state in message.Pucks)
             {
@@ -92,6 +101,13 @@ namespace Puckslide.Networking
                 return;
             }
 
+            string lobbyId = manager != null ? manager.LobbyId : null;
+            if (!string.IsNullOrEmpty(lobbyId) && message.LobbyId != lobbyId)
+            {
+                // Ignore snapshots from other lobbies or stale sessions.
+                return;
+            }
+
             if (PuckControllerRouteHub.TryGet(message.NetworkInstanceId, out PuckController controller))
             {
                 Rigidbody2D body = controller.Rigidbody;
@@ -102,6 +118,29 @@ namespace Puckslide.Networking
                     controller.transform.position = message.Position;
                 }
             }
+        }
+
+        private void OnDespawned(PuckDespawnMessage message)
+        {
+            NetworkSessionManager manager = NetworkSessionManager.Instance;
+            if (manager != null && manager.IsHost)
+            {
+                return;
+            }
+
+            if (message == null)
+            {
+                return;
+            }
+
+            string lobbyId = manager != null ? manager.LobbyId : null;
+            if (!string.IsNullOrEmpty(lobbyId) && message.LobbyId != lobbyId)
+            {
+                // Ignore snapshots from other lobbies or stale sessions.
+                return;
+            }
+
+            m_TargetStates.Remove(message.NetworkInstanceId);
         }
     }
 }

--- a/Puckslide/Assets/Scripts/State/LobbyState.cs
+++ b/Puckslide/Assets/Scripts/State/LobbyState.cs
@@ -65,6 +65,12 @@ public static class LobbyState
             return;
         }
 
+        string currentLobbyId = NetworkSessionManager.Instance?.LobbyId;
+        if (!string.IsNullOrEmpty(currentLobbyId) && snapshot.LobbyId != currentLobbyId)
+        {
+            return;
+        }
+
         if (snapshot.Snapshot == null)
         {
             snapshot.Snapshot = new LobbySnapshot


### PR DESCRIPTION
## Summary
- prevent client-side command fallback in networked mode and enforce host-only command application with proper disconnect cleanup
- add lobby ID guards to puck replication and lobby snapshots to ignore stale or cross-lobby data
- restrict simulation processing to hosts/offline play so clients rely on authoritative snapshots

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a8ad0864832f8863371e6d159454)